### PR TITLE
Add conditionals for device availability

### DIFF
--- a/flower-card.js
+++ b/flower-card.js
@@ -74,6 +74,9 @@ customElements.whenDefined('card-tools').then(() => {
       .meter > .bad {
         background-color: rgba(240,163,163);
       }
+      .meter > .unavailable {
+        background-color: rgba(158,158,158,1);
+      }
       .divider {
         height: 1px;
         background-color: #727272;
@@ -123,18 +126,19 @@ customElements.whenDefined('card-tools').then(() => {
       const attribute = (icon, attr, min, max) => {
         const unit = this.stateObj.attributes.unit_of_measurement_dict[attr];
         const val = this.stateObj.attributes[attr];
+        const aval = val !== 'unavailable' ? true : false;
         const pct = 100*Math.max(0, Math.min(1, (val-min)/(max-min)));
         return cardTools.LitHtml`
-        <div class="attribute tooltip" data-tooltip="${val + " "+ unit + " | " + min + " ~ " + max + " " + unit}" @click="${() => cardTools.moreInfo(this.stateObj.attributes.sensors[attr])}">
+        <div class="attribute tooltip" data-tooltip="${aval ? val + " "+ unit + " | " + min + " ~ " + max + " " + unit : val}" @click="${() => cardTools.moreInfo(this.stateObj.attributes.sensors[attr])}">
           <ha-icon .icon="${icon}"></ha-icon>
           <div class="meter red">
-            <span class="${val < min || val > max ? 'bad' : 'good'}" style="width: 100%;"></span>
+            <span class="${aval ? (val < min || val > max ? 'bad' : 'good') : 'unavailable'}" style="width: 100%;"></span>
           </div>
           <div class="meter green">
-            <span class="${val > max ? 'bad' : 'good'}" style="width:${pct}%;"></span>
+            <span class="${aval ? (val > max ? 'bad' : 'good') : 'unavailable'}" style="width:${aval ? pct : '0'}%;"></span>
           </div>
           <div class="meter red">
-            <span class="bad" style="width:${val > max ? 100 : 0}%;"></span>
+            <span class="bad" style="width:${aval ? (val > max ? 100 : 0) : '0'}%;"></span>
           </div>
         </div>
         `;


### PR DESCRIPTION
Hi @Olen,

Thanks for this project.

I will try to add my own contribution with regards to device availability.

Currently, when the device is "unavailable" (disconnected), the first 2 bars are green and 100% width. Which is very misleading in a dashboard context as there is no visual indicator there is actually a problem with that device.

So I have added an extra css class and a few ternaries and the result will now be this:
![image](https://user-images.githubusercontent.com/9019306/131644942-efecb648-a0d9-46a2-9e4a-5e849d2eb2c8.png)

Only the first bar is 100% and colour grey, while the other bars remain empty and the default background colour. The tooltip will also ONLY show "unavailable" instead of "unavailable C | value range"

I hope you find this useful and you will merge it in
Rob
