### PR TITLE
Add visual when plant has a problem

### DIFF
--- a/flower-card.js
+++ b/flower-card.js
@@ -45,6 +45,9 @@ customElements.whenDefined('card-tools').then(() => {
         text-transform: capitalize;
         display: block;
       }
+      #name ha-icon {
+          color: rgb(240, 163, 163);
+      }
       .header > #species {
         text-transform: capitalize;
         color: #8c96a5;
@@ -145,7 +148,7 @@ customElements.whenDefined('card-tools').then(() => {
       <ha-card>
         <div class="header" @click="${() => cardTools.moreInfo(this.stateObj.entity_id)}">
           <img src="${this.stateObj.attributes.image}">
-          <span id="name"> ${this.stateObj.attributes.name} </span>
+          <span id="name"> ${this.stateObj.attributes.name} <ha-icon .icon="mdi:${this.stateObj.state == 'problem' ? 'alert-circle-outline' : ''}"></ha-icon></span>
           <span id="species">${species} </span>
         </div>
         <div class="divider"></div>


### PR DESCRIPTION
@Olen 

One other small improvement, show an alert icon if the plant's state is "problem"

![image](https://user-images.githubusercontent.com/9019306/131667779-0aa0bfef-a6a6-4bd5-b1d6-172b0f4d3567.png)

I have tried having better conditional to not have code spat out when the "state" is ok, but was not able to through no means.

If you do a ternary over the whole markup, the markup gets rendered as string, rather than html elements.
If you keep it the same, but wrap the markup in `cardTools.LitHtml`, then the svg does not get loaded in, you are left with the markup not interpreted.

If you can think of a different approach I would be more than happy to test and push a new commit.

Thanks