### PR TITLE
Replaced 'brigthness' with 'illuminance'

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Add it as a custom card and select which bars you want to show on the card
 type: custom:flower-card
 entity: plant.my_plant
 show_bars:
-- brigthness
+- illuminance
 - humidity
 - moisture
 - conductivity


### PR DESCRIPTION
Replaced 'brigthness' (misspelled and incorrect) with 'illuminance' in the 'Setup card' yaml example code.