### PR TITLE
Fix issue with 3.0.0 lit-html module

### DIFF
--- a/flower-card.js
+++ b/flower-card.js
@@ -3,8 +3,7 @@ import {
   html,
   css,
 } from "https://unpkg.com/lit-element@3.0.1/lit-element.js?module";
-import {unsafeHTML} from 'https://unpkg.com/lit-html@latest/directives/unsafe-html.js?module';
-
+import {unsafeHTML} from 'https://unpkg.com/lit-html@2.8.0/directives/unsafe-html.js?module';
 
 export const fireEvent = (node, type, detail) => {
   detail = detail === null || detail === undefined ? {} : detail;


### PR DESCRIPTION
Card stopped working with 3.0.0 lit-html module - which is now the 'latest', since an update was published about 7 hours ago according to NPM and the 'module' throws an error/fails.

```
Cannot generate module for lit-html@3.0.0/lit-html.js
SyntaxError: unknown: Support for the experimental syntax 'logicalAssignment' isn't currently enabled (6:2831):
```

Rolling back to 2.8.0 fixes the issue.