### PR TITLE
fix: remove lit-element and lit-html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "custom-card-helpers": "^1.9.0",
         "home-assistant-js-websocket": "^8.0.1",
         "lit": "^2.8.0",
-        "lit-element": "^3.3.3",
-        "lit-html": "^2.8.0",
         "webpack": ">=5.94.0",
         "yarn": "^1.22.19"
       },
@@ -788,29 +786,7 @@
       "integrity": "sha512-s6tI33Lf6VpDu7u4YqsSX78D28bYQulM+VAzsGch4fx2H0eLZnJsUBsPWmGYSGoKDNbjtRv02rio1o+UdPVwvw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/@marcokreeft/ha-editor-formbuilder/node_modules/lit-element": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.0.tgz",
-      "integrity": "sha512-gSejRUQJuMQjV2Z59KAS/D4iElUhwKpIyJvZ9w+DIagIQjfJnhR20h2Q5ddpzXGS+fF0tMZ/xEYGMnKmaI/iww==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/@marcokreeft/ha-editor-formbuilder/node_modules/lit-html": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.0.tgz",
-      "integrity": "sha512-pwT/HwoxqI9FggTrYVarkBKFN9MlTUpLrDHubTmW4SrkL3kkqW5gxwbxMMUnbbRHBC0WTZnYHcjDSCM559VyfA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
+        "@lit/reactive-element": "^2.0.4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1914,7 +1890,7 @@
         "home-assistant-js-websocket": "^6.0.1",
         "intl-messageformat": "^9.11.1",
         "lit": "^2.1.1",
-        "rollup": "^2.63.0",
+        "rollup": "^2.79.2",
         "superstruct": "^0.15.3",
         "typescript": "^4.5.4"
       }
@@ -3790,6 +3766,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
       "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -4475,9 +4452,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "custom-card-helpers": "^1.9.0",
     "home-assistant-js-websocket": "^8.0.1",
     "lit": "^2.8.0",
-    "lit-element": "^3.3.3",
-    "lit-html": "^2.8.0",
     "webpack": ">=5.94.0",
     "yarn": "^1.22.19"
   },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,5 @@
-import { customElement, html } from "lit-element";
+import { html } from 'lit';
+import { customElement } from "lit/decorators.js";
 import { DisplayType } from "./types/flower-card-types";
 import { default_show_bars, plantAttributes } from "./utils/constants";
 import EditorForm from "@marcokreeft/ha-editor-formbuilder";

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -1,4 +1,5 @@
-import { CSSResult, HTMLTemplateResult, LitElement, customElement, html, property } from 'lit-element';
+import { CSSResult, HTMLTemplateResult, LitElement, html } from 'lit';
+import {customElement, property } from 'lit/decorators.js';
 import { HomeAssistant, LovelaceCardEditor } from 'custom-card-helpers';
 import { style } from './styles';
 import { DisplayType, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -1,6 +1,6 @@
 // import { HomeAssistant } from "custom-card-helpers";
 import { DisplayType, DisplayedAttribute, DisplayedAttributes, Icons, Limits, UOM, UOMT } from "../types/flower-card-types";
-import { TemplateResult, html } from "lit-element";
+import { TemplateResult, html } from "lit";
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { default_show_bars } from "./constants";
 import { moreInfo } from "./utils";


### PR DESCRIPTION
Based on [Lit upgrade guide](https://lit.dev/docs/v2/releases/upgrade/#update-packages-and-import-paths), fixes: #95 