### PR TITLE
Use primary-background-color variable for meter

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -98,7 +98,7 @@ export const style = css`
 }
 .meter {
   height: 8px;
-  background-color: #f1f1f1;
+  background-color: var(--primary-background-color);
   border-radius: 2px;
   display: inline-grid;
   overflow: hidden;


### PR DESCRIPTION
This allows themes to modify the background color of the meter. 

Main use case would be dark mode.