### PR TITLE
Display lux units with a logarithmic scale

### DIFF
--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -81,11 +81,14 @@ export const renderAttributes = (card: FlowerCard): TemplateResult[] => {
 export const renderAttribute = (card: FlowerCard, attr: DisplayedAttribute) => {
     const { max, min } = attr.limits;
     const unitTooltip = attr.unit_of_measurement;
+    const logScale = attr.unit_of_measurement === 'lx'
     const icon = attr.icon || "mdi:help-circle-outline";
     const val = attr.current || 0;
     const aval = !isNaN(val);
     const display_val = attr.display_state;
-    const pct = 100 * Math.max(0, Math.min(1, (val - min) / (max - min)));
+    const pct = !logScale
+        ? 100 * Math.max(0, Math.min(1, (val - min) / (max - min)))
+        : 100 * Math.max(0, Math.min(1, (Math.log(val) - Math.log(min)) / (Math.log(max) - Math.log(min))));
     const toolTipText = aval ? `${attr.name}: ${val} ${unitTooltip}<br>(${min} ~ ${max} ${unitTooltip})` : card._hass.localize('state.default.unavailable');
     const label = attr.name === 'dli' ? '<math style="display: inline-grid;" xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mfrac><mrow><mn>mol</mn></mrow><mrow><mn>d</mn><mn>⋅</mn><msup><mn>m</mn><mn>2</mn></msup></mrow></mfrac></mrow></math>' : unitTooltip
     const attributeCssClass = `attribute tooltip ${card.config.display_type === DisplayType.Compact ? 'width-100' : ''}`;


### PR DESCRIPTION
A logarithmic scale better correlates with human perception of light intensity.

To illustrate this, here's the daily luminosity from my plant sensor in a linear scale:

![image](https://github.com/user-attachments/assets/5bd622b8-e4a6-45d7-b355-2c914630fb9e)

and in a logarithmic scale:

![image](https://github.com/user-attachments/assets/b9e68d9b-dd77-4852-a83c-17b267e6b07f)


The second graph describes a lot better the luminosity yesterday (no, we did not experience a reverse eclipse 😄)