### PR TITLE
Add support for CO2 and soil temperature sensors

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,6 +10,8 @@ export const default_show_bars = [
     "illuminance",
     "humidity",
     "dli",
+    "co2",
+    "soil_temperature",
   ];
 
 export const missingImage = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaWRZTWlkIG1lZXQiIGZvY3VzYWJsZT0iZmFsc2UiIHJvbGU9ImltZyIgYXJpYS1oaWRkZW49InRydWUiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgICAgIDxnPgogICAgICA8IS0tP2xpdCQ0MTM0MjMxNjkkLS0+PHBhdGggZD0iTTMsMTNBOSw5IDAgMCwwIDEyLDIyQzEyLDE3IDcuOTcsMTMgMywxM00xMiw1LjVBMi41LDIuNSAwIDAsMSAxNC41LDhBMi41LDIuNSAwIDAsMSAxMiwxMC41QTIuNSwyLjUgMCAwLDEgOS41LDhBMi41LDIuNSAwIDAsMSAxMiw1LjVNNS42LDEwLjI1QTIuNSwyLjUgMCAwLDAgOC4xLDEyLjc1QzguNjMsMTIuNzUgOS4xMiwxMi41OCA5LjUsMTIuMzFDOS41LDEyLjM3IDkuNSwxMi40MyA5LjUsMTIuNUEyLjUsMi41IDAgMCwwIDEyLDE1QTIuNSwyLjUgMCAwLDAgMTQuNSwxMi41QzE0LjUsMTIuNDMgMTQuNSwxMi4zNyAxNC41LDEyLjMxQzE0Ljg4LDEyLjU4IDE1LjM3LDEyLjc1IDE1LjksMTIuNzVDMTcuMjgsMTIuNzUgMTguNCwxMS42MyAxOC40LDEwLjI1QzE4LjQsOS4yNSAxNy44MSw4LjQgMTYuOTcsOEMxNy44MSw3LjYgMTguNCw2Ljc0IDE4LjQsNS43NUMxOC40LDQuMzcgMTcuMjgsMy4yNSAxNS45LDMuMjVDMTUuMzcsMy4yNSAxNC44OCwzLjQxIDE0LjUsMy42OUMxNC41LDMuNjMgMTQuNSwzLjU2IDE0LjUsMy41QTIuNSwyLjUgMCAwLDAgMTIsMUEyLjUsMi41IDAgMCwwIDkuNSwzLjVDOS41LDMuNTYgOS41LDMuNjMgOS41LDMuNjlDOS4xMiwzLjQxIDguNjMsMy4yNSA4LjEsMy4yNUEyLjUsMi41IDAgMCwwIDUuNiw1Ljc1QzUuNiw2Ljc0IDYuMTksNy42IDcuMDMsOEM2LjE5LDguNCA1LjYsOS4yNSA1LjYsMTAuMjVNMTIsMjJBOSw5IDAgMCwwIDIxLDEzQzE2LDEzIDEyLDE3IDEyLDIyWiI+PC9wYXRoPgogICAgICA8L2c+Cjwvc3ZnPgo=";
@@ -20,5 +22,7 @@ export const plantAttributes : DropdownOption[] = [
   { label: 'Temperature', value: 'temperature' },
   { label: 'Illuminance', value: 'illuminance' },
   { label: 'Humidity', value: 'humidity' },
-  { label: 'Daily Light Integral', value: 'dli' }
+  { label: 'Daily Light Integral', value: 'dli' },
+  { label: 'CO2', value: 'co2' },
+  { label: 'Soil Temperature', value: 'soil_temperature' }
 ];

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -22,10 +22,12 @@ describe('constants', () => {
       expect(default_show_bars).toContain('illuminance');
       expect(default_show_bars).toContain('humidity');
       expect(default_show_bars).toContain('dli');
+      expect(default_show_bars).toContain('co2');
+      expect(default_show_bars).toContain('soil_temperature');
     });
 
-    it('should have 6 default attributes', () => {
-      expect(default_show_bars).toHaveLength(6);
+    it('should have 8 default attributes', () => {
+      expect(default_show_bars).toHaveLength(8);
     });
   });
 


### PR DESCRIPTION
## Summary

Add support for the new plant sensors that were recently added to the plant integration:
- **CO2** (`co2`)
- **Soil Temperature** (`soil_temperature`)

## Changes

- Add `co2` and `soil_temperature` to `default_show_bars` (displayed by default)
- Add dropdown options in the card editor for these sensors
- Update tests to reflect the new sensors

## Verification

Confirmed that the plant integration's websocket API (`plant/get_info`) already returns these sensors with the correct keys.

## Test plan

- [x] Tests pass (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] CI passes

Generated with [Claude Code](https://claude.ai/code)