### PR TITLE
Add custom name and hide species options

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -29,7 +29,9 @@ export class FlowerCardEditor extends EditorForm {
                 { label: 'Compact', value: DisplayType.Compact },
             ] }] },
             { controls: [{ label: "Entity", configValue: "entity", type: FormControlType.Dropdown, items: plantsList }] },
+            { controls: [{ label: "Name", configValue: "name", type: FormControlType.Textbox }] },
             { controls: [{ label: "Battery Sensor", configValue: "battery_sensor", type: FormControlType.Dropdown, items: batteryList }] },
+            { controls: [{ label: "Hide Species", configValue: "hide_species", type: FormControlType.Switch }] },
             { controls: [{ label: "Show Bars", configValue: "show_bars", type: FormControlType.Checkboxes, items: plantAttributes }] }
         ]);
     }    

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -99,6 +99,8 @@ export default class FlowerCard extends LitElement {
         }
 
         const species = this.stateObj.attributes.species;
+        const displayName = this.config.name || this.stateObj.attributes.friendly_name;
+        const hideSpecies = this.config.hide_species ?? false;
         const headerCssClass = this.config.display_type === DisplayType.Compact ? "header-compact" : "header";
         const haCardCssClass = this.config.display_type === DisplayType.Compact ? "" : "card-margin-top";
 
@@ -110,14 +112,13 @@ export default class FlowerCard extends LitElement {
                 ? this.stateObj.attributes.entity_picture
                 : missingImage
             }">
-                <span id="name"> ${this.stateObj.attributes.friendly_name
-            } <ha-icon .icon="mdi:${this.stateObj.state.toLowerCase() == "problem"
+                <span id="name"> ${displayName} <ha-icon .icon="mdi:${this.stateObj.state.toLowerCase() == "problem"
                 ? "alert-circle-outline"
                 : ""
             }"></ha-icon>
                 </span>
                 <span id="battery">${renderBattery(this)}</span>
-                <span id="species">${species} </span>
+                ${!hideSpecies ? html`<span id="species">${species}</span>` : ''}
             </div>
             <div class="divider"></div>
             ${renderAttributes(this)}

--- a/src/types/flower-card-types.ts
+++ b/src/types/flower-card-types.ts
@@ -5,6 +5,8 @@ export interface FlowerCardConfig extends LovelaceCardConfig {
     entity?: string;
     battery_sensor?: string;
     display_type?: DisplayType;
+    name?: string;
+    hide_species?: boolean;
 }
 
 export enum DisplayType {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { DisplayType, FlowerCardConfig } from '../src/types/flower-card-types';
+
+describe('FlowerCardConfig', () => {
+  describe('name option', () => {
+    it('should allow custom name to be set', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        name: 'My Custom Plant Name',
+      };
+
+      expect(config.name).toBe('My Custom Plant Name');
+    });
+
+    it('should be optional', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+      };
+
+      expect(config.name).toBeUndefined();
+    });
+  });
+
+  describe('hide_species option', () => {
+    it('should allow hiding species', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        hide_species: true,
+      };
+
+      expect(config.hide_species).toBe(true);
+    });
+
+    it('should default to showing species when not set', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+      };
+
+      // When hide_species is undefined, species should be shown (hide_species ?? false === false)
+      const hideSpecies = config.hide_species ?? false;
+      expect(hideSpecies).toBe(false);
+    });
+  });
+
+  describe('display_type option', () => {
+    it('should support Full display type', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        display_type: DisplayType.Full,
+      };
+
+      expect(config.display_type).toBe('full');
+    });
+
+    it('should support Compact display type', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        display_type: DisplayType.Compact,
+      };
+
+      expect(config.display_type).toBe('compact');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements feature request from #98 and supersedes #102 with a clean implementation.

### New config options:

1. **`name`** - Override the displayed plant name (falls back to entity's friendly_name)
2. **`hide_species`** - Hide the species text below the plant name

### Example config:

```yaml
type: custom:flower-card
entity: plant.my_monstera
name: "Living Room Monstera"
hide_species: true
```

Both options are available in the visual card editor.

## Changes

- `src/types/flower-card-types.ts` - Add `name` and `hide_species` to config interface
- `src/flower-card.ts` - Use custom name with fallback, conditionally render species
- `src/editor.ts` - Add Name textbox and Hide Species switch to editor
- `tests/config.test.ts` - Add tests for new config options

## Test plan

- [x] All tests pass (22 tests)
- [x] Lint passes
- [ ] CI passes

Closes #98
Supersedes #102

Generated with [Claude Code](https://claude.ai/code)