### PR TITLE
Fix display bugs for negative temperatures and zero illuminance

### DIFF
--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -2,6 +2,35 @@ import { describe, it, expect } from 'vitest';
 import { getChunkedDisplayed } from '../src/utils/attributes';
 import { DisplayedAttribute, DisplayedAttributes } from '../src/types/flower-card-types';
 
+describe('display_state regex', () => {
+  // Test the regex pattern used for extracting numeric values
+  const regex = /[^\d,.+-]/g;
+
+  it('should preserve negative numbers', () => {
+    const input = '-5.2 °C';
+    const result = input.replace(regex, '');
+    expect(result).toBe('-5.2');
+  });
+
+  it('should preserve positive numbers', () => {
+    const input = '25.5 °C';
+    const result = input.replace(regex, '');
+    expect(result).toBe('25.5');
+  });
+
+  it('should preserve zero', () => {
+    const input = '0 lx';
+    const result = input.replace(regex, '');
+    expect(result).toBe('0');
+  });
+
+  it('should handle comma decimal separators', () => {
+    const input = '1.234,56 µS/cm';
+    const result = input.replace(regex, '');
+    expect(result).toBe('1.234,56');
+  });
+});
+
 const createMockAttribute = (name: string): DisplayedAttribute => ({
   name,
   current: 50,


### PR DESCRIPTION
## Summary

Fixes two display bugs:

### 1. Negative temperatures not showing minus sign (#157)

The regex pattern for extracting numeric values from formatted state strings was stripping the minus sign. Fixed by including `-` in the allowed characters.

**Before:** `-5.2 °C` → `5.2`
**After:** `-5.2 °C` → `-5.2`

### 2. Illuminance showing as unavailable when value is 0 (#79)

The logarithmic scale calculation for illuminance (lux) was failing when the value was 0, since `log(0)` is undefined. Fixed by falling back to linear scale when value or min is 0.

## Changes

- `src/utils/attributes.ts` - Fix regex pattern, fix log scale edge case
- `tests/attributes.test.ts` - Add tests for numeric extraction regex

## Test plan

- [x] All tests pass (26 tests)
- [x] Lint passes
- [ ] CI passes

Fixes #157
Fixes #79

Generated with [Claude Code](https://claude.ai/code)