### PR TITLE
Fix species name capitalization

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -81,12 +81,10 @@ export const style = css`
     color: rgb(240, 163, 163);
 }
 .header > #species {
-  text-transform: capitalize;
   color: #8c96a5;
   display: block;
 }
 .header-compact > #species {
-  text-transform: capitalize;
   line-height: 85%;
   color: #8c96a5;
   font-size: 0.8em;


### PR DESCRIPTION
## Summary

Remove `text-transform: capitalize` from species element CSS to display species names as provided by the plant integration.

## Problem

In binomial nomenclature, only the genus name should be capitalized:
- ✅ Correct: "Solanum lycopersicum"
- ❌ Wrong: "Solanum Lycopersicum"

The CSS was incorrectly capitalizing every word.

## Solution

This is a coordinated fix with the plant integration (Olen/homeassistant-plant#320):
- **Plant integration**: Now capitalizes only the first letter of species names
- **Flower card**: Removes CSS that was capitalizing every word

## Changes

- Remove `text-transform: capitalize` from `.header > #species`
- Remove `text-transform: capitalize` from `.header-compact > #species`

## Fixes

Fixes #173

## Test plan

- [x] Lint passes
- [x] All 58 tests pass
- [ ] Visual check: species names display with correct capitalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)