### PR TITLE
Get unit of measurement from entity state attributes

### DIFF
--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -44,8 +44,11 @@ export const renderAttributes = (card: FlowerCard): TemplateResult[] => {
         const result = card.plantinfo.result;
         for (const elem of monitored) {
             if (result[elem]) {
-                const { max, min, current, icon, sensor, unit_of_measurement } = result[elem];
-                const display_state = card._hass.formatEntityState(card._hass.states[sensor]).replace(/[^\d,.+-]/g, "");
+                const { max, min, current, icon, sensor } = result[elem];
+                const entityState = card._hass.states[sensor];
+                const display_state = card._hass.formatEntityState(entityState).replace(/[^\d,.+-]/g, "");
+                // Get unit from entity state attributes (respects user customizations)
+                const unit_of_measurement = entityState?.attributes?.unit_of_measurement || result[elem].unit_of_measurement || "";
                 const limits: Limits = { max: Number(max), min: Number(min) };
                 displayed[elem] = {
                     name: elem,


### PR DESCRIPTION
## Summary

Use entity state attributes for `unit_of_measurement` instead of the websocket response. This respects user customizations made in Home Assistant's entity settings.

## Problem

Previously, the unit of measurement was fetched from the websocket response, which returns the integration's default unit. If a user customized the unit in HA's entity settings, it wouldn't be reflected in the card.

## Solution

Get `unit_of_measurement` from `entityState.attributes.unit_of_measurement` with fallback to the websocket value if not available.

This completes the fix started earlier where `formatEntityState` was used for precision but the unit was still from websocket.

## Fixes

Fixes #42

## Test plan

- [x] Lint passes
- [x] All 58 tests pass
- [ ] Manual: Customize unit on a sensor entity, verify card shows custom unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)