### PR TITLE
Add text-overflow ellipsis for long species names

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -83,6 +83,9 @@ export const style = css`
 .header > #species {
   color: #8c96a5;
   display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .header-compact > #species {
   line-height: 85%;
@@ -92,6 +95,9 @@ export const style = css`
   margin-right: 4px;
   opacity: 0.4;
   display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .meter {
   height: 8px;


### PR DESCRIPTION
## Summary

Long species names now truncate with ellipsis instead of overflowing the card.

## Problem

Long species names (e.g., "Spathiphyllum cochlearispathum") overflow the card boundaries on mobile devices and narrow displays.

## Solution

Added CSS for text truncation with ellipsis:
- `overflow: hidden`
- `text-overflow: ellipsis`
- `white-space: nowrap`

Applied to both `.header > #species` and `.header-compact > #species`.

## Note

Users who want to hide the species entirely can use the existing `hide_species: true` config option (added in PR #190).

## Fixes

Fixes #183

## Test plan

- [x] Lint passes
- [x] All 58 tests pass
- [ ] Visual: Long species names truncate with "..." on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)