### PR TITLE
Add hide_image config option

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -32,6 +32,7 @@ export class FlowerCardEditor extends EditorForm {
             { controls: [{ label: "Name", configValue: "name", type: FormControlType.Textbox }] },
             { controls: [{ label: "Battery Sensor", configValue: "battery_sensor", type: FormControlType.Dropdown, items: batteryList }] },
             { controls: [{ label: "Hide Species", configValue: "hide_species", type: FormControlType.Switch }] },
+            { controls: [{ label: "Hide Image", configValue: "hide_image", type: FormControlType.Switch }] },
             { controls: [{ label: "Show Bars", configValue: "show_bars", type: FormControlType.Checkboxes, items: plantAttributes }] }
         ]);
     }    

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -99,17 +99,19 @@ export default class FlowerCard extends LitElement {
         const species = this.stateObj.attributes.species;
         const displayName = this.config.name || this.stateObj.attributes.friendly_name;
         const hideSpecies = this.config.hide_species ?? false;
+        const hideImage = this.config.hide_image ?? false;
         const headerCssClass = this.config.display_type === DisplayType.Compact ? "header-compact" : "header";
-        const haCardCssClass = this.config.display_type === DisplayType.Compact ? "" : "card-margin-top";
+        const haCardCssClass = (this.config.display_type === DisplayType.Compact || hideImage) ? "" : "card-margin-top";
+        const noImageClass = hideImage ? " no-image" : "";
 
         return html`
             <ha-card class="${haCardCssClass}">
-            <div class="${headerCssClass}" @click="${() =>
+            <div class="${headerCssClass}${noImageClass}" @click="${() =>
                 moreInfo(this, this.stateObj.entity_id)}">
-                <img src="${this.stateObj.attributes.entity_picture
+                ${!hideImage ? html`<img src="${this.stateObj.attributes.entity_picture
                 ? this.stateObj.attributes.entity_picture
                 : missingImage
-            }">
+            }">` : ''}
                 <span id="name"> ${displayName} <ha-icon .icon="mdi:${this.stateObj.state.toLowerCase() == "problem"
                 ? "alert-circle-outline"
                 : ""

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -62,6 +62,22 @@ export const style = css`
   float: left;
   box-shadow: var( --ha-card-box-shadow, 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2) );
 }
+.header.no-image {
+  height: auto;
+  padding: 16px;
+}
+.header.no-image + .divider {
+  margin-top: 0;
+}
+.header-compact.no-image {
+  height: auto;
+  padding: 8px 16px;
+}
+.header.no-image > #name,
+.header-compact.no-image > #name {
+  margin-top: 0;
+  margin-left: 0;
+}
 .header > #name {
   font-weight: bold;
   width: 100%;

--- a/src/types/flower-card-types.ts
+++ b/src/types/flower-card-types.ts
@@ -7,6 +7,7 @@ export interface FlowerCardConfig extends LovelaceCardConfig {
     display_type?: DisplayType;
     name?: string;
     hide_species?: boolean;
+    hide_image?: boolean;
 }
 
 export enum DisplayType {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -46,6 +46,29 @@ describe('FlowerCardConfig', () => {
     });
   });
 
+  describe('hide_image option', () => {
+    it('should allow hiding image', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        hide_image: true,
+      };
+
+      expect(config.hide_image).toBe(true);
+    });
+
+    it('should default to showing image when not set', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+      };
+
+      // When hide_image is undefined, image should be shown (hide_image ?? false === false)
+      const hideImage = config.hide_image ?? false;
+      expect(hideImage).toBe(false);
+    });
+  });
+
   describe('display_type option', () => {
     it('should support Full display type', () => {
       const config: FlowerCardConfig = {


### PR DESCRIPTION
## Summary

Add option to hide the plant image to save space, especially useful for compact view or when plants don't have images.

## Config

```yaml
type: custom:flower-card
entity: plant.my_plant
hide_image: true
```

## Changes

- Add `hide_image` to FlowerCardConfig type
- Add "Hide Image" toggle to visual editor
- Conditionally render image in card
- Add CSS styles for proper layout when image is hidden
- Remove top margin when image is hidden (no overlap needed)
- Add tests for hide_image option

## Fixes

Fixes #123

## Test plan

- [x] Lint passes
- [x] All 60 tests pass (2 new tests)
- [ ] Visual: Card displays correctly with `hide_image: true`
- [ ] Visual: Works in both full and compact modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)