### PR TITLE
Make release workflow depend on Test & Lint success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,45 +2,66 @@
 name: "Auto Release"
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'package.json'
+  workflow_run:
+    workflows: ["Test & Lint"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: write
 
 jobs:
   release:
     name: "Create Release"
     runs-on: "ubuntu-latest"
+    # Only run if Test & Lint succeeded
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: "✏️ Checkout code"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: "📋 Check if package.json changed"
+        id: check_package
+        run: |
+          BEFORE_SHA=$(git rev-parse HEAD~1 2>/dev/null || echo "")
+          if [ -z "$BEFORE_SHA" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            CHANGED=$(git diff --name-only $BEFORE_SHA HEAD -- 'package.json' | wc -l)
+            if [ "$CHANGED" -gt 0 ]; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
 
       - name: "🏷️ Get version tag"
         id: set_var
         run: echo "COMPONENT_VERSION=$(grep version package.json | cut -d ':' -f 2 | sed -e 's/[^0-9\.beta\-]//g')" >> $GITHUB_ENV
+        if: steps.check_package.outputs.changed == 'true'
 
       - name: "🏷️ Check if tag exists already"
         uses: mukunku/tag-exists-action@v1.6.0
         id: "check_tag"
         with:
           tag: "v${{ env.COMPONENT_VERSION }}"
+        if: steps.check_package.outputs.changed == 'true'
 
-      - name: "❌ Cancel if tag is already present"
-        run: |
-          echo "Tag already present: v${{ env.COMPONENT_VERSION }}. Not creating a new release"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.check_tag.outputs.exists == 'true'
+      - name: "⏭️ Skip if no package change or tag exists"
+        run: echo "Skipping release - package.json unchanged or tag already exists"
+        if: steps.check_package.outputs.changed != 'true' || steps.check_tag.outputs.exists == 'true'
 
       - name: "🗝️ Get previous release version"
         id: last_release
-        uses: InsonusK/get-latest-release@v1.1.0
-        with:
-          myToken: ${{ github.token }}
-          exclude_types: "draft|prerelease"
+        run: |
+          LAST_TAG=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // empty')
+          echo "tag_name=${LAST_TAG}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
 
       - name: "🏷️ Create new tag"
         uses: rickstaa/action-create-tag@v1
@@ -49,36 +70,39 @@ jobs:
           tag: "v${{ env.COMPONENT_VERSION }}"
           tag_exists_error: false
           message: "Version ${{ env.COMPONENT_VERSION }}"
+        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
 
       - name: "🗒️ Generate release changelog"
         id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        uses: heinrichreimer/github-changelog-generator-action@v2.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sinceTag: ${{ steps.last_release.outputs.tag_name }}
           headerLabel: "# Notable changes since ${{ steps.last_release.outputs.tag_name }}"
           stripGeneratorNotice: true
+          output: RELEASE_CHANGELOG.md
+        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
 
       - name: "👍 Create Stable release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           prerelease: false
-          body: "${{ steps.changelog.outputs.changelog }}"
+          body_path: RELEASE_CHANGELOG.md
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
           files: |
             flower-card.js
             flower-card.js.gz
-        if: contains(env.COMPONENT_VERSION, 'beta') == false
+        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true' && contains(env.COMPONENT_VERSION, 'beta') == false
 
       - name: "🤞 Create Beta release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           prerelease: true
-          body: "${{ steps.changelog.outputs.changelog }}"
+          body_path: RELEASE_CHANGELOG.md
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
           files: |
             flower-card.js
             flower-card.js.gz
-        if: contains(env.COMPONENT_VERSION, 'beta') == true
+        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true' && contains(env.COMPONENT_VERSION, 'beta') == true


### PR DESCRIPTION
## Summary
Updates the release workflow to only run after the Test & Lint workflow completes successfully.

### Changes
- Use `workflow_run` trigger instead of `push` trigger
- Only create release if `github.event.workflow_run.conclusion == 'success'`
- Check if `package.json` changed before attempting release
- Update action versions to match plant repo

This ensures releases are only created when tests pass, consistent with the other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)