### PR TITLE
Add isPpfdUnit helper for PPFD unit detection

### DIFF
--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -5,6 +5,16 @@ import { default_show_bars } from "./constants";
 import { moreInfo } from "./utils";
 import FlowerCard from "../flower-card";
 
+/**
+ * Check if a unit indicates PPFD (not lux).
+ * Covers: µmol/s⋅m², μmol/s⋅m², mol/s⋅m², etc.
+ */
+export const isPpfdUnit = (unit: string | undefined | null): boolean => {
+    if (!unit) return false;
+    const lowerUnit = unit.toLowerCase();
+    return lowerUnit.includes('mol');
+};
+
 export const renderBattery = (card: FlowerCard) => {
     if(!card.config.battery_sensor) return html``;
 


### PR DESCRIPTION
## Summary

Adds `isPpfdUnit()` helper function to detect PPFD units for sensors like FYTA that report light in PPFD instead of lux.

## Changes

### src/utils/attributes.ts
- Added `isPpfdUnit(unit)` function that returns `true` if unit contains 'mol'
- Covers: `µmol/s⋅m²`, `μmol/s⋅m²`, `mol/s⋅m²`, `mol/d⋅m²` (DLI), etc.

### tests/attributes.test.ts
- Added comprehensive tests for `isPpfdUnit`
- Added PPFD percentage calculation tests (verifies linear scale used)

## Context

This is a preparatory change for better FYTA/PPFD sensor support. Related to Olen/homeassistant-plant#151.

## Test plan

- [x] All 96 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)