### PR TITLE
Add support for rolling 24-hour DLI sensor (dli_24h)

### DIFF
--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -248,7 +248,7 @@ export const renderAttribute = (card: FlowerCard, attr: DisplayedAttribute) => {
         ? 100 * Math.max(0, Math.min(1, (val - min) / (max - min)))
         : 100 * Math.max(0, Math.min(1, (Math.log(val) - Math.log(min)) / (Math.log(max) - Math.log(min))));
     const toolTipText = aval ? `${attr.name}: ${val} ${unitTooltip}<br>(${min} ~ ${max} ${unitTooltip})` : card._hass.localize('state.default.unavailable');
-    const label = attr.name === 'dli' ? '<math style="display: inline-grid;" xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mfrac><mrow><mn>mol</mn></mrow><mrow><mn>d</mn><mn>⋅</mn><msup><mn>m</mn><mn>2</mn></msup></mrow></mfrac></mrow></math>' : unitTooltip
+    const label = (attr.name === 'dli' || attr.name === 'dli_24h') ? '<math style="display: inline-grid;" xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mfrac><mrow><mn>mol</mn></mrow><mrow><mn>d</mn><mn>⋅</mn><msup><mn>m</mn><mn>2</mn></msup></mrow></mfrac></mrow></math>' : unitTooltip
     // Determine settings with explicit overrides taking precedence over display_type defaults
     const isCompact = card.config.display_type === DisplayType.Compact;
     const barsPerRow = card.config.bars_per_row ?? (isCompact ? 1 : 2);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,6 +21,7 @@ export const plantAttributes : DropdownOption[] = [
   { label: 'Illuminance', value: 'illuminance' },
   { label: 'Humidity', value: 'humidity' },
   { label: 'Daily Light Integral', value: 'dli' },
+  { label: 'DLI (24h rolling)', value: 'dli_24h' },
   { label: 'CO2', value: 'co2' },
   { label: 'Soil Temperature', value: 'soil_temperature' }
 ];


### PR DESCRIPTION
## Summary

- Add `dli_24h` to plantAttributes dropdown in the card editor
- Apply DLI unit formatting (mol/d⋅m²) to `dli_24h` as well as `dli`

## Background

This corresponds to the new rolling 24-hour DLI sensor added to the homeassistant-plant integration (PR https://github.com/Olen/homeassistant-plant/pull/327).

The new sensor provides a continuous rolling 24-hour window for DLI instead of the standard midnight reset.

## Test plan

- [x] All tests pass (96 passed)
- [ ] Manual test: Configure card to show dli_24h attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)