### PR TITLE
Release 2026.1.1 (stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.1.1-beta4",
+  "version": "2026.1.1",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
## Summary
- Bump version from 2026.1.1-beta4 to 2026.1.1 (stable release)
- No negative feedback received from beta testing

Merging will trigger the automated release workflow.