### PR TITLE
docs: overhaul README, split extra badges to separate file

### DIFF
--- a/EXTRA_BADGES.md
+++ b/EXTRA_BADGES.md
@@ -1,0 +1,212 @@
+# 🏷️ Extra Badges
+
+Add additional icons and information next to the battery icon in your Flower Card. Useful for displaying room sensors, binary states, action buttons, or static labels.
+
+> [!NOTE]
+> Extra badges must be configured via YAML. GUI configuration is not currently supported for this option.
+
+By default, only the icon is displayed. Hovering shows a tooltip with the entity name and state. Set `show_state: true` to display the state value next to the icon.
+
+---
+
+## 📑 Table of Contents
+
+- [🏷️ Extra Badges](#️-extra-badges)
+  - [⚙️ Badge Options](#️-badge-options)
+  - [📡 Entity-Based Badge](#-entity-based-badge)
+  - [🔘 Binary Sensor Badge](#-binary-sensor-badge)
+  - [📋 Attribute Badge](#-attribute-badge)
+  - [🏷️ Static Icon/Text Badge](#️-static-icontext-badge)
+  - [🔲 Action Button Badge](#-action-button-badge)
+  - [🧩 Combined Example](#-combined-example)
+
+---
+
+## ⚙️ Badge Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `entity` | string | Entity ID of a sensor or binary_sensor |
+| `attribute` | string | Entity attribute to display instead of state (e.g., `last_changed`) |
+| `text` | string | Static text to display (alternative to entity) |
+| `icon` | string | Icon to display (default: entity's icon or `mdi:information`) |
+| `color` | string | Icon color for sensors/text |
+| `color_on` | string | Icon color when binary_sensor is "on" (default: primary color) |
+| `color_off` | string | Icon color when binary_sensor is "off" (default: disabled color) |
+| `show_state` | boolean | Show the entity's state value next to the icon (default: `false`) |
+
+---
+
+## 📡 Entity-Based Badge
+
+Display a sensor with an icon (tooltip shows state on hover):
+
+```yaml
+extra_badges:
+  - entity: sensor.room_temperature
+    icon: mdi:thermometer
+```
+
+Display a sensor with icon **and** state value visible:
+
+```yaml
+extra_badges:
+  - entity: sensor.room_humidity
+    icon: mdi:water-percent
+    show_state: true
+```
+
+---
+
+## 🔘 Binary Sensor Badge
+
+Display a binary sensor with different colors for on/off states:
+
+```yaml
+extra_badges:
+  - entity: binary_sensor.window_open
+    icon: mdi:window-open-variant
+    color_on: orange
+    color_off: grey
+  - entity: binary_sensor.plant_needs_water
+    icon: mdi:water-alert
+    color_on: red
+    color_off: green
+```
+
+---
+
+## 📋 Attribute Badge
+
+Display an entity attribute instead of its state. Useful for `last_changed`, `last_updated`, or any custom attribute:
+
+```yaml
+extra_badges:
+  - entity: sensor.plant_moisture
+    attribute: last_changed
+    icon: mdi:clock
+```
+
+With the attribute value visible:
+
+```yaml
+extra_badges:
+  - entity: sensor.plant_moisture
+    attribute: last_changed
+    icon: mdi:clock
+    show_state: true
+```
+
+Custom attribute (e.g., battery level from a sensor's attributes):
+
+```yaml
+extra_badges:
+  - entity: sensor.plant_moisture
+    attribute: battery_level
+    icon: mdi:battery
+    show_state: true
+```
+
+---
+
+## 🏷️ Static Icon/Text Badge
+
+Decorative icon with no text or tooltip:
+
+```yaml
+extra_badges:
+  - icon: mdi:flower
+    color: pink
+```
+
+Static icon with tooltip text on hover:
+
+```yaml
+extra_badges:
+  - text: Indoor
+    icon: mdi:home
+    color: blue
+```
+
+Static icon with text visible next to it:
+
+```yaml
+extra_badges:
+  - text: Zone A
+    icon: mdi:map-marker
+    color: green
+    show_state: true
+```
+
+Text only (no icon) — set `icon: none`:
+
+```yaml
+extra_badges:
+  - text: Kitchen
+    icon: none
+    color: blue
+    show_state: true
+```
+
+---
+
+## 🔲 Action Button Badge
+
+Use an `input_button` entity to trigger scripts or automations directly from the plant card.
+
+**Step 1:** Create an input_button helper:
+
+```yaml
+# configuration.yaml or via UI: Settings → Devices & Services → Helpers
+input_button:
+  water_plant:
+    name: Water Plant
+    icon: mdi:watering-can
+```
+
+**Step 2:** Add the button to your card:
+
+```yaml
+extra_badges:
+  - entity: input_button.water_plant
+```
+
+**Step 3:** Create an automation for the button press:
+
+```yaml
+automation:
+  - alias: "Water plant when button pressed"
+    triggers:
+      - trigger: state
+        entity_id: input_button.water_plant
+    actions:
+      - action: switch.turn_on
+        target:
+          entity_id: switch.plant_water_pump
+      - delay: "00:00:30"
+      - action: switch.turn_off
+        target:
+          entity_id: switch.plant_water_pump
+```
+
+This lets you control plant-related devices (pumps, grow lights, etc.) directly from the Flower Card.
+
+---
+
+## 🧩 Combined Example
+
+```yaml
+type: custom:flower-card
+entity: plant.my_plant
+battery_sensor: sensor.plant_battery
+extra_badges:
+  - entity: sensor.room_humidity
+    icon: mdi:water-percent
+  - entity: binary_sensor.grow_light_on
+    icon: mdi:lightbulb
+    color_on: yellow
+    color_off: grey
+  - text: Kitchen
+    icon: mdi:silverware-fork-knife
+  - entity: input_button.water_plant
+```

--- a/README.md
+++ b/README.md
@@ -1,33 +1,77 @@
-# Flower Card
+# 🌸 Flower Card for Home Assistant
 
-**This fork of the flower-card depends on this Plant component:
-https://github.com/Olen/homeassistant-plant**
+[![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
+[![GitHub Release](https://img.shields.io/github/v/release/Olen/lovelace-flower-card?style=for-the-badge)](https://github.com/Olen/lovelace-flower-card/releases)
 
-The card can be set up from the GUI
+A Lovelace card for displaying plant data from the [Plant Monitor](https://github.com/Olen/homeassistant-plant) integration. Shows sensor readings, thresholds, and health status in a compact visual layout.
 
-![image](https://github.com/user-attachments/assets/a2b1aea4-c2ed-4305-9b14-10ae2d17a34a)
+> [!IMPORTANT]
+> This card requires the [Plant Monitor](https://github.com/Olen/homeassistant-plant) custom integration. It is **not** compatible with the built-in plant integration.
 
-## Configuration Options
+---
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `entity` | string | **Required** | The plant entity ID |
-| `name` | string | Entity name | Custom display name for the plant |
-| `display_type` | string | `full` | Display mode: `full` or `compact` |
-| `hide_units` | boolean | Based on display_type | Hide value/unit next to bars |
-| `bars_per_row` | number | Based on display_type | Number of bars per row (1 or 2) |
-| `battery_sensor` | string | - | Entity ID of a battery sensor to display |
-| `show_bars` | list | All | List of measurement bars to show |
-| `hide_species` | boolean | `false` | Hide the species name |
-| `hide_image` | boolean | `false` | Hide the plant image |
-| `extra_badges` | list | - | Additional icons to display (see below) |
+## 📑 Table of Contents
 
-### Basic Example
+- [🌸 Flower Card for Home Assistant](#-flower-card-for-home-assistant)
+  - [📦 Installation](#-installation)
+  - [⚙️ Configuration](#️-configuration)
+  - [🖼️ Display Types](#️-display-types)
+  - [📊 Show Bars](#-show-bars)
+  - [🔋 Battery Sensor](#-battery-sensor)
+  - [🏷️ Extra Badges](#️-extra-badges)
+  - [🎨 Other Options](#-other-options)
+  - [☕ Support](#-support)
+
+---
+
+## 📦 Installation
+
+### Via HACS *(recommended)*
+
+1. Add this repo as a [Custom Repository](https://hacs.xyz/docs/faq/custom_repositories/) with type **Dashboard**
+2. Click **Install** in the "Flower Card" card in HACS
+3. Refresh the frontend (shift-reload your browser)
+
+### Manual Installation
+
+1. Download `flower-card.js` and place it in your `<config>/www/` folder
+2. Go to **Settings** → **Dashboards** → **Resources**
+3. Add the resource:
+   ```yaml
+   Url: /local/<path to>/flower-card.js
+   Resource type: JavaScript Module
+   ```
+4. Refresh the frontend
+
+---
+
+## ⚙️ Configuration
+
+The card can be set up from the GUI:
+
+![GUI editor](https://github.com/user-attachments/assets/a2b1aea4-c2ed-4305-9b14-10ae2d17a34a)
+
+Or via YAML:
 
 ```yaml
 type: custom:flower-card
 entity: plant.my_plant
 ```
+
+### All Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `entity` | string | **Required** | The plant entity ID |
+| `name` | string | Entity name | Custom display name |
+| `display_type` | string | `full` | Display mode: `full` or `compact` |
+| `hide_units` | boolean | Based on display_type | Hide value/unit next to bars |
+| `bars_per_row` | number | Based on display_type | Number of bars per row (1 or 2) |
+| `battery_sensor` | string | — | Entity ID of a battery sensor |
+| `show_bars` | list | All | Measurement bars to show |
+| `hide_species` | boolean | `false` | Hide the species name |
+| `hide_image` | boolean | `false` | Hide the plant image |
+| `extra_badges` | list | — | Additional icons ([details](EXTRA_BADGES.md)) |
 
 ### Full Example
 
@@ -53,35 +97,44 @@ extra_badges:
     color_on: orange
     color_off: grey
 ```
-<img width="484" height="256" alt="image" src="https://github.com/user-attachments/assets/faeaeb66-7990-4bbe-9af4-3a4d8648c1c8" />
 
+<img width="484" height="256" alt="Full card example" src="https://github.com/user-attachments/assets/faeaeb66-7990-4bbe-9af4-3a4d8648c1c8" />
 
+---
 
-### Display Type
+## 🖼️ Display Types
 
-Set `display_type` to `compact` for a smaller card layout:
+### Full *(default)*
+
+```yaml
+type: custom:flower-card
+entity: plant.my_plant
+display_type: full
+```
+
+### Compact
+
+A smaller card layout with hidden units and single-column bars:
 
 ```yaml
 type: custom:flower-card
 entity: plant.my_plant
 display_type: compact
 ```
-<img width="483" height="291" alt="image" src="https://github.com/user-attachments/assets/4951c49f-a112-43af-9684-c399bd30dd94" />
 
+<img width="483" height="291" alt="Compact card" src="https://github.com/user-attachments/assets/4951c49f-a112-43af-9684-c399bd30dd94" />
 
-### Fine-grained Display Settings
+### Fine-Grained Overrides
 
-The `display_type` sets defaults for several display options. You can override these individually:
+The display type sets defaults you can override individually:
 
-| Setting | Full (default) | Compact |
-|---------|----------------|---------|
+| Setting | Full | Compact |
+|---------|------|---------|
 | `hide_units` | `false` | `true` |
 | `bars_per_row` | `2` | `1` |
 
-Mix and match settings to customize the layout:
-
 ```yaml
-# Compact header but show 2 bars per row with units
+# Compact header but 2 bars per row with units
 type: custom:flower-card
 entity: plant.my_plant
 display_type: compact
@@ -89,64 +142,13 @@ bars_per_row: 2
 hide_units: false
 ```
 
-```yaml
-# Full header but hide units
-type: custom:flower-card
-entity: plant.my_plant
-display_type: full
-hide_units: true
-```
+---
 
-```yaml
-# Full header with 1 bar per row (vertical layout)
-type: custom:flower-card
-entity: plant.my_plant
-bars_per_row: 1
-```
-
-### Custom Name
-
-Override the default entity name:
-
-```yaml
-type: custom:flower-card
-entity: plant.my_plant
-name: "Living Room Monstera"
-```
-
-### Hide Species / Image
-
-Hide the species name or plant image:
-
-```yaml
-type: custom:flower-card
-entity: plant.my_plant
-hide_species: true
-hide_image: true
-```
-
-### Battery Sensor
-
-Add a battery sensor icon to the card header. The icon changes color based on battery level:
-- \>= 40%: Green
-- 20-39%: Orange
-- < 20%: Red
-
-```yaml
-type: custom:flower-card
-entity: plant.my_plant
-battery_sensor: sensor.plant_sensor_battery
-```
-
-![image](https://user-images.githubusercontent.com/203184/190199923-6060efbf-7306-49e5-bbc4-26dc922d3180.png)
-
-### Show Bars
+## 📊 Show Bars
 
 Select which measurement bars to display:
 
 ```yaml
-type: custom:flower-card
-entity: plant.my_plant
 show_bars:
   - moisture
   - temperature
@@ -155,138 +157,31 @@ show_bars:
 
 Available bars: `moisture`, `temperature`, `conductivity`, `illuminance`, `humidity`, `dli`, `co2`, `soil_temperature`
 
-### Extra Badges
+---
 
-Add additional icons next to the battery icon. Useful for displaying room sensors, binary states, or static labels.
+## 🔋 Battery Sensor
 
-**Note:** Extra badges must be configured via YAML. GUI configuration is not currently supported for this option.
+Add a battery indicator to the card header. The icon changes color based on level:
 
-By default, only the icon is displayed. Hovering over the icon shows a tooltip with the entity name and state. Set `show_state: true` to display the state value next to the icon.
-
-#### Extra Badge Options
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `entity` | string | Entity ID of a sensor or binary_sensor |
-| `attribute` | string | Entity attribute to display instead of state (e.g., `last_changed`) |
-| `text` | string | Static text to display (alternative to entity) |
-| `icon` | string | Icon to display (default: entity's icon or `mdi:information`) |
-| `color` | string | Icon color for sensors/text |
-| `color_on` | string | Icon color when binary_sensor is "on" (default: primary color) |
-| `color_off` | string | Icon color when binary_sensor is "off" (default: disabled color) |
-| `show_state` | boolean | Show the entity's state value next to the icon (default: `false`) |
-
-#### Entity-based Badge
-
-Display a sensor with an icon (tooltip shows state on hover):
+| Level | Color |
+|-------|-------|
+| >= 40% | 🟢 Green |
+| 20–39% | 🟠 Orange |
+| < 20% | 🔴 Red |
 
 ```yaml
-extra_badges:
-  - entity: sensor.room_temperature
-    icon: mdi:thermometer
+battery_sensor: sensor.plant_sensor_battery
 ```
 
-Display a sensor with icon and state value visible:
+![Battery sensor](https://user-images.githubusercontent.com/203184/190199923-6060efbf-7306-49e5-bbc4-26dc922d3180.png)
+
+---
+
+## 🏷️ Extra Badges
+
+Add additional icons next to the battery icon — sensor values, binary states, action buttons, or static labels.
 
 ```yaml
-extra_badges:
-  - entity: sensor.room_humidity
-    icon: mdi:water-percent
-    show_state: true
-```
-
-#### Binary Sensor Badge
-
-Display a binary sensor with different colors for on/off states:
-
-```yaml
-extra_badges:
-  - entity: binary_sensor.window_open
-    icon: mdi:window-open-variant
-    color_on: orange
-    color_off: grey
-  - entity: binary_sensor.plant_needs_water
-    icon: mdi:water-alert
-    color_on: red
-    color_off: green
-```
-
-#### Attribute Badge
-
-Display an entity attribute instead of its state. Useful for showing `last_changed`, `last_updated`, or any custom attribute:
-
-```yaml
-extra_badges:
-  - entity: sensor.plant_moisture
-    attribute: last_changed
-    icon: mdi:clock
-```
-
-Display the attribute value next to the icon:
-
-```yaml
-extra_badges:
-  - entity: sensor.plant_moisture
-    attribute: last_changed
-    icon: mdi:clock
-    show_state: true
-```
-
-Display a custom attribute (e.g., battery level from a sensor's attributes):
-
-```yaml
-extra_badges:
-  - entity: sensor.plant_moisture
-    attribute: battery_level
-    icon: mdi:battery
-    show_state: true
-```
-
-#### Static Icon/Text Badge
-
-Display a decorative icon with no text or tooltip:
-
-```yaml
-extra_badges:
-  - icon: mdi:flower
-    color: pink
-```
-
-Display a static icon (tooltip shows text on hover):
-
-```yaml
-extra_badges:
-  - text: Indoor
-    icon: mdi:home
-    color: blue
-```
-
-Display a static icon with text visible next to it:
-
-```yaml
-extra_badges:
-  - text: Zone A
-    icon: mdi:map-marker
-    color: green
-    show_state: true
-```
-
-Display text only (no icon) by setting `icon: none`:
-
-```yaml
-extra_badges:
-  - text: Kitchen
-    icon: none
-    color: blue
-    show_state: true
-```
-
-#### Combined Example
-
-```yaml
-type: custom:flower-card
-entity: plant.my_plant
-battery_sensor: sensor.plant_battery
 extra_badges:
   - entity: sensor.room_humidity
     icon: mdi:water-percent
@@ -294,91 +189,36 @@ extra_badges:
     icon: mdi:lightbulb
     color_on: yellow
     color_off: grey
-  - text: Kitchen
-    icon: mdi:silverware-fork-knife
-```
-
-#### Triggering Automations with Input Button
-
-You can use an `input_button` entity with extra_badges to trigger scripts or automations directly from the plant card. When clicked, the button press triggers your automation.
-
-**Step 1:** Create an input_button helper in Home Assistant:
-
-```yaml
-# configuration.yaml or via UI: Settings → Devices & Services → Helpers
-input_button:
-  water_plant:
-    name: Water Plant
-    icon: mdi:watering-can
-```
-
-**Step 2:** Add the button to your plant card:
-
-```yaml
-type: custom:flower-card
-entity: plant.my_plant
-extra_badges:
   - entity: input_button.water_plant
 ```
 
-**Step 3:** Create an automation that triggers when the button is pressed:
+For the full reference with all badge types and options, see **[EXTRA_BADGES.md](EXTRA_BADGES.md)**.
+
+---
+
+## 🎨 Other Options
+
+### Custom Name
 
 ```yaml
-automation:
-  - alias: "Water plant when button pressed"
-    triggers:
-      - trigger: state
-        entity_id: input_button.water_plant
-    actions:
-      - action: switch.turn_on
-        target:
-          entity_id: switch.plant_water_pump
-      - delay: "00:00:30"
-      - action: switch.turn_off
-        target:
-          entity_id: switch.plant_water_pump
+name: "Living Room Monstera"
 ```
 
-This allows you to control plant-related devices (pumps, grow lights, etc.) directly from the flower card.
-
-## Dependencies
-1. Custom Plant integration (https://github.com/Olen/homeassistant-plant)
-
-## Installation
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
-
-This can be installed manually or through HACS
-### Via HACS
-* Add this repo as a "Custom repository" with type "Dashboard"
-  * Click HACS in your Home Assistant
-  * Click Frontend
-  * Click the 3 dots in the top right corner and select "Custom Repositories"
-  * Add the URL to this github repository and type "Dashboard"
-* Click "Install" in the new "Flower Card" card in HACS.
-* Wait for install to complete
-* You should not need to restart Home Assistant, but will probably need to refresh the frontend and/or "shift-reload" to refresh the browser cache.
-
-### Manual Installation
-1: Download the file flower-card.js and add it to somewhere in your `<config>/www/` folder in HA 
- 
-2: Click your profile picture in the bottom left corner -> Turn on Advanced Mode.
- 
-3: Go to Configuration -> Lovelace Dashboards -> Resources -> press the + (lower right corner of screen) and add the following information:
+### Hide Species / Image
 
 ```yaml
-  Url: /local/<path to>/flower-card.js
-  Resource type: JavaScript Module
+hide_species: true
+hide_image: true
 ```
-![image](https://user-images.githubusercontent.com/45675902/80322223-ebd41880-8823-11ea-992d-7070d4197f8b.png)
 
-4: Press *Create* afterwards to add the new resource.
+---
 
-5: You should not need to restart Home Assistant, but will probably need to refresh the frontend and/or "shift-reload" to refresh the browser cache.
-
-
-### Disclaimer
-I looked into several forks of the original card https://github.com/thomasloven/lovelace-flower-card. Some forks were very interesting and I edited several of those source codes changes into my own new fork. Credits to those original authors. After version 3.0.0 the card was more or less completely rewritten, and only the design and layout of the original card has been kept.
+## ☕ Support
 
 <a href="https://www.buymeacoffee.com/olatho" target="_blank">
-<img src="https://user-images.githubusercontent.com/203184/184674974-db7b9e53-8c5a-40a0-bf71-c01311b36b0a.png" style="height: 50px !important;"> 
+<img src="https://user-images.githubusercontent.com/203184/184674974-db7b9e53-8c5a-40a0-bf71-c01311b36b0a.png" style="height: 50px !important;">
 </a>
+
+---
+
+*This card is a fork of [thomasloven/lovelace-flower-card](https://github.com/thomasloven/lovelace-flower-card). After version 3.0.0 the card was largely rewritten; only the original design and layout have been kept.*

--- a/info.md
+++ b/info.md
@@ -1,32 +1,19 @@
-# BREAKING CHANGES COMING UP
+# 🌸 Flower Card
 
->**Warning**
->
-> **This card is about to be completely rewritten.  The next version will *not* be compatible with the original plant integration in HA or with this release.**
+A Lovelace card for displaying plant data from the [Plant Monitor](https://github.com/Olen/homeassistant-plant) integration.
 
-## Breaking Changes
+> [!IMPORTANT]
+> Requires the [Plant Monitor](https://github.com/Olen/homeassistant-plant) custom integration.
 
-This card will, from version 2.0.0, only work with version 2.0.0 or higher of https://github.com/Olen/homeassistant-plant/.  Please read the README from that repository carefully before upgrading.
+## ✨ Features
 
-## Requires
-1. [Lovelace card tools](https://github.com/thomasloven/lovelace-card-tools)
-2. [Custom plant integration](https://github.com/Olen/homeassistant-plant/)
+- 🖥️ **GUI editor** — set up cards without YAML
+- 📊 **Sensor bars** — moisture, temperature, conductivity, illuminance, humidity, DLI, CO2, soil temperature
+- 🔋 **Battery indicator** — color-coded battery level
+- 🏷️ **Extra badges** — add room sensors, binary states, action buttons, or labels
+- 🖼️ **Display modes** — full or compact layout
+- 🌡️ **Unit support** — handles both °C and °F
 
+## 📖 Documentation
 
-## Features in v1.0.0
-
-* Will use attributes from the plant _entity_ to display thresholds.
-* Displays nice bars for moisture, conductivity, temperature, illumination
-
-![v1.0.0](https://github.com/remkolems/lovelace-flower-card/blob/master/lovelace-flower-card_popup.png)
-
-
-## Features coming in v2.0.0
-
-* Will use attributes from the plant _device_ to display thresholds.
-* Displays nice bars for moisture, conductivity, temperature, illumination, _humidity_ and _daily light integral_
-* Configuration of the card to select which bars to display
-* Make sure you install version 2.0.0 or higher of https://github.com/Olen/homeassistant-plant/. 
-
-![v2.0.0](https://user-images.githubusercontent.com/203184/182670259-9abd27c3-8641-444f-9002-4ffc0a80c016.png)
-
+See the [README](https://github.com/Olen/lovelace-flower-card/) for configuration options and examples.


### PR DESCRIPTION
## Summary
- Rewrite README with TOC, emoji headers, and consistent styling
- Move the long Extra Badges section (~180 lines) to EXTRA_BADGES.md
- Update info.md for HACS
- Consistent look and feel with Plant Monitor docs

## Test plan
- [ ] Documentation-only changes, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)