### PR TITLE
Add configurable battery warning thresholds

### DIFF
--- a/src/types/flower-card-types.ts
+++ b/src/types/flower-card-types.ts
@@ -22,6 +22,8 @@ export interface FlowerCardConfig extends LovelaceCardConfig {
     hide_species?: boolean;
     hide_image?: boolean;
     extra_badges?: ExtraBadge[];
+    battery_warn_level?: number;   // Below this → red (default: 20)
+    battery_ok_level?: number;     // Above this → green (default: 40)
 }
 
 export enum DisplayType {

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -22,22 +22,32 @@ export const renderBattery = (card: FlowerCard) => {
     if(!battery_sensor) return html``;
 
     const state = parseInt(battery_sensor.state);
+    const warnLevel = card.config.battery_warn_level ?? 20;
+    const okLevel = card.config.battery_ok_level ?? 40;
+
+    const getColor = (threshold: number): string => {
+        if (threshold >= okLevel) return "green";
+        if (threshold >= warnLevel) return "orange";
+        return "red";
+    };
 
     const levels = [
-        { threshold: 90, icon: "mdi:battery", color: "green" },
-        { threshold: 80, icon: "mdi:battery-90", color: "green" },
-        { threshold: 70, icon: "mdi:battery-80", color: "green" },
-        { threshold: 60, icon: "mdi:battery-70", color: "green" },
-        { threshold: 50, icon: "mdi:battery-60", color: "green" },
-        { threshold: 40, icon: "mdi:battery-50", color: "green" },
-        { threshold: 30, icon: "mdi:battery-40", color: "orange" },
-        { threshold: 20, icon: "mdi:battery-30", color: "orange" },
-        { threshold: 10, icon: "mdi:battery-20", color: "red" },
-        { threshold: 0, icon: "mdi:battery-10", color: "red" },
-        { threshold: -Infinity, icon: "mdi:battery-alert-variant-outline", color: "red" },
+        { threshold: 90, icon: "mdi:battery" },
+        { threshold: 80, icon: "mdi:battery-90" },
+        { threshold: 70, icon: "mdi:battery-80" },
+        { threshold: 60, icon: "mdi:battery-70" },
+        { threshold: 50, icon: "mdi:battery-60" },
+        { threshold: 40, icon: "mdi:battery-50" },
+        { threshold: 30, icon: "mdi:battery-40" },
+        { threshold: 20, icon: "mdi:battery-30" },
+        { threshold: 10, icon: "mdi:battery-20" },
+        { threshold: 0, icon: "mdi:battery-10" },
+        { threshold: -Infinity, icon: "mdi:battery-alert-variant-outline" },
     ];
 
-    const { icon, color } = levels.find(({ threshold }) => state > threshold) ||  { icon: "mdi:battery-alert-variant-outline", color: "red" };
+    const level = levels.find(({ threshold }) => state > threshold) || { threshold: -Infinity, icon: "mdi:battery-alert-variant-outline" };
+    const icon = level.icon;
+    const color = getColor(state);
 
     return html`
         <div class="battery tooltip" @click="${(e: Event) => { e.stopPropagation(); moreInfo(card, card.config.battery_sensor)}}">

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -186,4 +186,41 @@ describe('FlowerCardConfig', () => {
       expect(barsPerRow).toBe(1);
     });
   });
+
+  describe('battery threshold options', () => {
+    it('should allow configuring battery_warn_level', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        battery_sensor: 'sensor.plant_battery',
+        battery_warn_level: 10,
+      };
+
+      expect(config.battery_warn_level).toBe(10);
+    });
+
+    it('should allow configuring battery_ok_level', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        battery_sensor: 'sensor.plant_battery',
+        battery_ok_level: 25,
+      };
+
+      expect(config.battery_ok_level).toBe(25);
+    });
+
+    it('should default to 20 and 40 when not set', () => {
+      const config: FlowerCardConfig = {
+        type: 'flower-card',
+        entity: 'plant.my_plant',
+        battery_sensor: 'sensor.plant_battery',
+      };
+
+      const warnLevel = config.battery_warn_level ?? 20;
+      const okLevel = config.battery_ok_level ?? 40;
+      expect(warnLevel).toBe(20);
+      expect(okLevel).toBe(40);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `battery_warn_level` and `battery_ok_level` YAML config options to customize battery indicator color thresholds
- Defaults remain unchanged (20/40) for backwards compatibility
- YAML-only, no UI editor changes

Fixes #236

## Test plan
- [x] Existing battery tests pass
- [x] New config tests for threshold options added
- [ ] Manual test with custom thresholds in YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)