### PR TITLE
Add VPD to available plant attributes

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,5 +23,6 @@ export const plantAttributes : DropdownOption[] = [
   { label: 'Daily Light Integral', value: 'dli' },
   { label: 'DLI (24h rolling)', value: 'dli_24h' },
   { label: 'CO2', value: 'co2' },
-  { label: 'Soil Temperature', value: 'soil_temperature' }
+  { label: 'Soil Temperature', value: 'soil_temperature' },
+  { label: 'VPD', value: 'vpd' }
 ];


### PR DESCRIPTION
## Summary
- Add VPD (Vapour Pressure Deficit) as a selectable attribute in show_bars
- Not included in default bars — fully backwards compatible
- Plants without VPD data (older integration or no temp+humidity sensors) simply skip it

Requires Olen/homeassistant-plant#403 for VPD data.

## Test plan
- [x] All 115 tests pass
- [x] No changes to default behavior — VPD only shown when user explicitly adds it to show_bars
- [x] Card gracefully handles missing VPD data (existing `if (result[elem])` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)