### PR TITLE
Release v2026.6.0-beta1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flower-card",
-  "version": "2026.4.1",
+  "version": "2026.6.0-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flower-card",
-      "version": "2026.4.1",
+      "version": "2026.6.0-beta1",
       "license": "MIT",
       "dependencies": {
         "babel-loader": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.4.1",
+  "version": "2026.6.0-beta1",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
Beta release for **Home Assistant 2026.6**.

Bumps the version to `2026.6.0-beta1` to ship the [card picker entity suggestions](https://github.com/Olen/lovelace-flower-card/pull/250) (`getEntitySuggestion`, HA 2026.6+) as a prerelease.

Version-only change (`package.json` + lockfile stamp). Per the CI release pipeline, the build/tag/GitHub prerelease are produced automatically once this merges — no local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)