### PR TITLE
ci: bump Node 20 actions to Node 24 and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # Keep GitHub Actions current (e.g. Node runtime deprecations).
+  # All action bumps are grouped into a single weekly PR to limit noise.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Keep npm dependencies current. Grouped by type so security/patch updates
+  # land together rather than as many individual PRs.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies"
+      - "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: "✏️ Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -45,7 +45,7 @@ jobs:
         if: steps.check_package.outputs.changed == 'true'
 
       - name: "🏷️ Check if tag exists already"
-        uses: mukunku/tag-exists-action@v1.6.0
+        uses: mukunku/tag-exists-action@v1.7.0
         id: "check_tag"
         with:
           tag: "v${{ env.COMPONENT_VERSION }}"
@@ -56,7 +56,7 @@ jobs:
         if: steps.check_package.outputs.changed != 'true' || steps.check_tag.outputs.exists == 'true'
 
       - name: "📦 Setup Node.js"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -130,7 +130,7 @@ jobs:
         if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
 
       - name: "👍 Create Stable release"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: false
           body_path: RELEASE_CHANGELOG.md
@@ -142,7 +142,7 @@ jobs:
         if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true' && contains(env.COMPONENT_VERSION, 'beta') == false
 
       - name: "🤞 Create Beta release"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: true
           body_path: RELEASE_CHANGELOG.md

--- a/.github/workflows/remove-awaiting-feedback.yml
+++ b/.github/workflows/remove-awaiting-feedback.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ !github.event.issue.pull_request }}
     steps:
       - name: Remove awaiting feedback label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const labelName = 'awaiting feedback';

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark stale issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const daysUntilStale = 14;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Setup Node.js"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'


### PR DESCRIPTION
## Why

GitHub flagged (in the v2026.6.0-beta1 release run) that several actions still run on **Node 20**, which is force-migrated to **Node 24 on 2026-06-16** and removed on 2026-09-16.

## Action bumps (all Node-based actions → latest Node 24 majors)

| Action | Before | After | Notes |
|--------|--------|-------|-------|
| `actions/checkout` | v4 | **v6** | basic usage (`fetch-depth`, `ref`) — compatible |
| `actions/setup-node` | v4 | **v6** | basic usage (`node-version`, `cache`) — compatible |
| `actions/github-script` | v7 | **v9** | runtime-only; script API unchanged |
| `mukunku/tag-exists-action` | v1.6.0 | **v1.7.0** | verified `outputs.exists` unchanged |
| `softprops/action-gh-release` | v2 | **v3** | per release notes, pure Node 20→24 runtime move, no input changes |

The two remaining actions — `rickstaa/action-create-tag` and `heinrichreimer/github-changelog-generator-action` — are **Docker-based**, so they have no Node runtime to deprecate and are left as-is.

## Dependabot

Adds `.github/dependabot.yml` to keep things current automatically going forward:
- **github-actions** ecosystem — weekly, all bumps grouped into one PR (so future Node-runtime deprecations are caught automatically).
- **npm** ecosystem — weekly, grouped by prod/dev (the repo currently has 15 flagged vulnerabilities; this gives them a path to landing). Major bumps still come as individual PRs for review.

Config-only change — no source or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)