### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/remove-awaiting-feedback.yml
+++ b/.github/workflows/remove-awaiting-feedback.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+# Least-privilege: only needs to remove a label from issues.
+permissions:
+  issues: write
+
 jobs:
   remove-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 6 * * *"  # Run daily at 6 AM UTC
   workflow_dispatch:  # Allow manual trigger
 
+# Least-privilege: only needs to label issues.
+permissions:
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ name: "Test & Lint"
 on:
   push:
 
+# Least-privilege: this workflow only checks out and builds.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "Test & Lint"


### PR DESCRIPTION
## What

Three workflows had no top-level `permissions:` block, so they inherited the repo-default `GITHUB_TOKEN` scope. Pin each to the minimum it actually needs (defense-in-depth — `release.yml` already scopes itself):

| Workflow | Scope | Why |
|----------|-------|-----|
| `test.yml` | `contents: read` | checkout + build only |
| `stale-issues.yml` | `issues: write` | labels stale issues |
| `remove-awaiting-feedback.yml` | `issues: write` | removes a label |

Config-only; no behavior change. This was the minor hardening item from the post-merge security review (no injection vulnerabilities were found in the workflows themselves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)