### PR TITLE
Add optional care-info display

### DIFF
--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -5,7 +5,7 @@ import { style } from './styles';
 import { DisplayType, EntitySuggestion, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
 import * as packageJson from '../package.json';
 import { renderAttributes, renderBattery, renderCareInfo, renderExtraBadges } from './utils/attributes';
-import { CARD_NAME, default_show_bars, missingImage, plantAttributes } from './utils/constants';
+import { CARD_NAME, careFields, default_show_bars, missingImage, plantAttributes } from './utils/constants';
 import { isMediaSourceUrl, moreInfo, resolveMediaSource } from './utils/utils';
 
 console.info(
@@ -122,6 +122,22 @@ export default class FlowerCard extends LitElement {
                 {
                     type: "expandable",
                     name: "",
+                    title: "Care Info",
+                    schema: [
+                        {
+                            name: "show_care",
+                            selector: {
+                                select: {
+                                    multiple: true,
+                                    options: careFields
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    type: "expandable",
+                    name: "",
                     title: "Appearance",
                     schema: [
                         {
@@ -157,6 +173,7 @@ export default class FlowerCard extends LitElement {
                     display_type: "Display Type",
                     battery_sensor: "Battery Sensor",
                     show_bars: "Show Bars",
+                    show_care: "Show Care Info",
                     hide_species: "Hide Species",
                     hide_image: "Hide Image",
                     hide_units: "Hide Units"

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -4,7 +4,7 @@ import { HomeAssistant } from 'custom-card-helpers';
 import { style } from './styles';
 import { DisplayType, EntitySuggestion, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
 import * as packageJson from '../package.json';
-import { renderAttributes, renderBattery, renderExtraBadges } from './utils/attributes';
+import { renderAttributes, renderBattery, renderCareInfo, renderExtraBadges } from './utils/attributes';
 import { CARD_NAME, default_show_bars, missingImage, plantAttributes } from './utils/constants';
 import { isMediaSourceUrl, moreInfo, resolveMediaSource } from './utils/utils';
 
@@ -231,6 +231,7 @@ export default class FlowerCard extends LitElement {
             </div>
             <div class="divider"></div>
             ${renderAttributes(this)}
+            ${renderCareInfo(this)}
             </ha-card>
             `;
     }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -219,4 +219,30 @@ export const style = css`
     display: none;
   }
 }
+.care-info {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.care-item {
+  display: flex;
+  flex-direction: column;
+}
+.care-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+.care-heading ha-icon {
+  color: var(--secondary-text-color);
+}
+.care-text {
+  white-space: normal;
+  overflow-wrap: break-word;
+  line-height: 1.4;
+  color: var(--secondary-text-color);
+}
 `;

--- a/src/types/flower-card-types.ts
+++ b/src/types/flower-card-types.ts
@@ -22,6 +22,7 @@ export interface FlowerCardConfig extends LovelaceCardConfig {
     hide_species?: boolean;
     hide_image?: boolean;
     extra_badges?: ExtraBadge[];
+    show_care?: string[];      // selected care_* attribute keys to display (default: none)
     battery_warn_level?: number;   // Below this → red (default: 20)
     battery_ok_level?: number;     // Above this → green (default: 40)
 }

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -1,9 +1,35 @@
 import { DisplayType, DisplayedAttribute, DisplayedAttributes, ExtraBadge, Limits } from "../types/flower-card-types";
 import { TemplateResult, html } from "lit";
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { default_show_bars } from "./constants";
+import { careFields, careIcons, default_show_bars } from "./constants";
 import { moreInfo } from "./utils";
 import FlowerCard from "../flower-card";
+
+export interface CareEntry {
+    key: string;
+    label: string;
+    icon: string;
+    text: string;
+}
+
+// Pure selection: returns the care fields to render, in careFields order,
+// for the selected keys that have non-empty text on the entity.
+export const selectCareInfo = (
+    attributes: Record<string, unknown> | undefined,
+    showCare: string[] | undefined,
+): CareEntry[] => {
+    if (!attributes || !showCare || showCare.length === 0) return [];
+    return careFields
+        .filter(field => showCare.includes(field.value))
+        .map(field => ({
+            key: field.value,
+            label: field.label,
+            icon: careIcons[field.value],
+            text: attributes[field.value],
+        }))
+        .filter((entry): entry is CareEntry =>
+            typeof entry.text === 'string' && entry.text.trim() !== '');
+};
 
 /**
  * Check if a unit indicates PPFD (not lux).

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -31,6 +31,27 @@ export const selectCareInfo = (
             typeof entry.text === 'string' && entry.text.trim() !== '');
 };
 
+export const renderCareInfo = (card: FlowerCard): TemplateResult => {
+    const entity = card.config.entity;
+    const attributes = entity ? card._hass.states[entity]?.attributes : undefined;
+    const entries = selectCareInfo(attributes, card.config.show_care);
+    if (entries.length === 0) return html``;
+
+    return html`
+        <div class="care-info">
+            ${entries.map(entry => html`
+                <div class="care-item">
+                    <div class="care-heading">
+                        <ha-icon .icon="${entry.icon}"></ha-icon>
+                        <span>${entry.label}</span>
+                    </div>
+                    <div class="care-text">${entry.text}</div>
+                </div>
+            `)}
+        </div>
+    `;
+};
+
 /**
  * Check if a unit indicates PPFD (not lux).
  * Covers: µmol/s⋅m², μmol/s⋅m², mol/s⋅m², etc.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,3 +29,19 @@ export const plantAttributes : DropdownOption[] = [
   { label: 'Soil Temperature', value: 'soil_temperature' },
   { label: 'VPD', value: 'vpd' }
 ];
+
+export const careFields: DropdownOption[] = [
+  { label: 'Watering', value: 'care_watering' },
+  { label: 'Sunlight', value: 'care_sunlight' },
+  { label: 'Soil', value: 'care_soil' },
+  { label: 'Pruning', value: 'care_pruning' },
+  { label: 'Fertilization', value: 'care_fertilization' }
+];
+
+export const careIcons: Record<string, string> = {
+  care_watering: 'mdi:watering-can-outline',
+  care_sunlight: 'mdi:white-balance-sunny',
+  care_soil: 'mdi:shovel',
+  care_pruning: 'mdi:content-cut',
+  care_fertilization: 'mdi:bottle-tonic-outline',
+};

--- a/tests/care.test.ts
+++ b/tests/care.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { selectCareInfo } from '../src/utils/attributes';
+
+describe('selectCareInfo', () => {
+  const attrs = {
+    care_watering: 'Water weekly.',
+    care_sunlight: 'Bright indirect light.',
+    care_soil: '   ',                       // whitespace-only -> treated as absent
+    care_fertilization: 'Feed monthly in spring.',
+    // care_pruning intentionally absent
+  };
+
+  it('returns empty when show_care is undefined or empty', () => {
+    expect(selectCareInfo(attrs, undefined)).toEqual([]);
+    expect(selectCareInfo(attrs, [])).toEqual([]);
+  });
+
+  it('returns empty when attributes are missing', () => {
+    expect(selectCareInfo(undefined, ['care_watering'])).toEqual([]);
+  });
+
+  it('includes selected fields that are present and non-empty', () => {
+    const result = selectCareInfo(attrs, ['care_watering', 'care_fertilization']);
+    expect(result.map(e => e.key)).toEqual(['care_watering', 'care_fertilization']);
+    expect(result[0].text).toBe('Water weekly.');
+    expect(result[0].label).toBe('Watering');
+    expect(result[0].icon).toBe('mdi:watering-can-outline');
+  });
+
+  it('skips selected fields that are absent', () => {
+    const result = selectCareInfo(attrs, ['care_pruning', 'care_watering']);
+    expect(result.map(e => e.key)).toEqual(['care_watering']);
+  });
+
+  it('skips selected fields that are whitespace-only', () => {
+    expect(selectCareInfo(attrs, ['care_soil'])).toEqual([]);
+  });
+
+  it('orders results by careFields order, not selection order', () => {
+    const result = selectCareInfo(attrs, ['care_fertilization', 'care_watering', 'care_sunlight']);
+    expect(result.map(e => e.key)).toEqual(['care_watering', 'care_sunlight', 'care_fertilization']);
+  });
+
+  it('skips non-string attribute values', () => {
+    expect(selectCareInfo({ care_watering: 42 }, ['care_watering'])).toEqual([]);
+  });
+});

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CARD_NAME, default_show_bars, missingImage, plantAttributes } from '../src/utils/constants';
+import { CARD_NAME, default_show_bars, missingImage, plantAttributes, careFields, careIcons } from '../src/utils/constants';
 
 describe('constants', () => {
   describe('CARD_NAME', () => {
@@ -55,6 +55,37 @@ describe('constants', () => {
       default_show_bars.forEach((bar) => {
         expect(attrValues).toContain(bar);
       });
+    });
+  });
+
+  describe('careFields', () => {
+    it('has the five OpenPlantbook care fields with care_ prefixed values', () => {
+      const values = careFields.map(f => f.value);
+      expect(values).toEqual([
+        'care_watering',
+        'care_sunlight',
+        'care_soil',
+        'care_pruning',
+        'care_fertilization',
+      ]);
+    });
+
+    it('has a label and value for each field', () => {
+      careFields.forEach(f => {
+        expect(typeof f.label).toBe('string');
+        expect(typeof f.value).toBe('string');
+      });
+    });
+
+    it('has a matching mdi icon for every care field', () => {
+      careFields.forEach(f => {
+        expect(careIcons[f.value]).toMatch(/^mdi:/);
+      });
+    });
+
+    it('has no icon keys that are not care fields', () => {
+      const fieldValues = careFields.map(f => f.value).sort();
+      expect(Object.keys(careIcons).sort()).toEqual(fieldValues);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in way to display OpenPlantbook **care guidance** in the card. The plant integration ([homeassistant-plant#451](https://github.com/Olen/homeassistant-plant/pull/451), now merged) exposes per-species care prose as flat entity state attributes: `care_watering`, `care_sunlight`, `care_soil`, `care_pruning`, `care_fertilization`.

- New **`show_care`** config: a multi-select of which care fields to show (opt-in; nothing shows by default). Mirrors the existing `show_bars` pattern.
- Each selected, present field renders as a labeled text box (icon + heading + full prose) below the bars, in `careFields` order.
- **Graceful degradation:** selected-but-absent or whitespace-only fields are skipped; renders nothing when no care info is available — so it's safe before/independent of the integration update.
- Editor: a "Care Info" expandable section with the `show_care` selector.

Reads care data from entity attributes (`hass.states[...].attributes`), so it's isolated from the `plant/get_info` WebSocket path.

Verified the attribute names/structure/order against the merged integration code — they match exactly.

## Test Plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 129 pass (incl. new `selectCareInfo` + `careFields`/`careIcons` tests)
- [x] `npm run build` — compiles; `.gz` valid and byte-identical to `flower-card.js`
- [ ] Live HA: on a plant with populated `care_*` attributes, select fields under **Care Info** in the editor and confirm the prose renders; confirm a plant with no care attributes shows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)