### PR TITLE
Release v2026.6.0-beta2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flower-card",
-  "version": "2026.6.0-beta1",
+  "version": "2026.6.0-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flower-card",
-      "version": "2026.6.0-beta1",
+      "version": "2026.6.0-beta2",
       "license": "MIT",
       "dependencies": {
         "babel-loader": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.6.0-beta1",
+  "version": "2026.6.0-beta2",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
Beta release carrying the optional **care-info display** (#272), timed to match the corresponding `homeassistant-plant` beta that's about to bake.

Version-only change (`package.json` + lockfile stamp). Per the CI release pipeline, the build/tag/GitHub **prerelease** are produced automatically on merge — no local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)