### PR TITLE
Release v2026.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.6.0-beta2",
+  "version": "2026.6.0",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
Promote `2026.6.0-beta2` to stable. Includes the Care Info display (Show Care Info selector + care_* rendering). package.json version only; the Auto Release workflow builds flower-card.js, tags, and publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)