### PR TITLE
Remove text-transform from header styles

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -85,14 +85,12 @@ export const style = css`
   font-weight: bold;
   width: 100%;
   margin-top: 16px;
-  text-transform: capitalize;
   display: block;
 }
 .header-compact > #name {
   font-weight: bold;
   width: 100%;
   margin-top: 8px;
-  text-transform: capitalize;
   display: block;
   white-space: nowrap;
 }


### PR DESCRIPTION
👋 @Olen! Many thanks for this card, looks amazing!

A quick humble suggestion: I wonder if we can remove auto-capitalization in the card title. Two lines in the diff come from a pretty early commit: https://github.com/Olen/lovelace-flower-card/commit/431091438525946b85b90bf392ba3b709059e838

I've got a couple of plant names where only the first letter is using UPPER CASE. When the card renders, capitalization is added to every word in the name including prepositions which looks a bit odd.

I _guess_ that HA users have a habit of capitalizing names where needed in the entity itself, so changing that in the card does not necessarily match expectations. 

If you still think that capitalization is useful in the title, how about applying it only to [::first-letter](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::first-letter) instead of each word?

---

A bit more context on `text-transform: capitalize`:
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-transform#capitalize
<img width="777" height="430" alt="Screenshot 2026-06-06 at 02 01 33" src="https://github.com/user-attachments/assets/59224aeb-2dc5-4d36-98ba-5018fcaa1a32" />

---
In the meantime, I am using a CSS override via [`card_mod`](https://github.com/thomasloven/lovelace-card-mod) (needs to be applied to each card):

```yaml
type: custom:flower-card
entity: plant.XYZ
battery_sensor: # ...
show_bars: # ...
card_mod:
  style: |
    span#name { text-transform: none !important; }
```

