### PR TITLE
fix: show value/unit in full-width bars when hide_units is false (#287)

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -136,8 +136,8 @@ export const style = css`
 .attribute.tooltip.width-100 .meter.green {
   max-width: 90%;
 }
-.attribute.tooltip.width-100 .header {
-  display: none;
+.attribute.tooltip.width-100.has-units .meter.green {
+  max-width: 70%;
 }
 .meter > span {
   grid-row: 1;
@@ -205,12 +205,9 @@ export const style = css`
           transform: translateX(-50%) translateY(-200%);
 }
 .width-100 {
-  width: 100%;    
+  width: 100%;
   margin-bottom: 3px;
   margin-right: 5px;
-}
-.width-100 .header {
-  display: none;
 }
 @media (max-width: 600px) {
   .header > .unit {

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -324,7 +324,9 @@ export const renderAttribute = (card: FlowerCard, attr: DisplayedAttribute) => {
     const showUnits = !(card.config?.hide_units ?? isCompact);
     const useFullWidth = barsPerRow === 1;
 
-    const attributeCssClass = `attribute tooltip ${useFullWidth ? 'width-100' : ''}`;
+    // In full-width mode, mark when the value/unit header is shown so the
+    // bar can leave room for it (see .has-units in styles.ts).
+    const attributeCssClass = `attribute tooltip ${useFullWidth ? 'width-100' : ''}${useFullWidth && showUnits ? ' has-units' : ''}`;
 
     return html`
         <div class="${attributeCssClass}" @click="${() => moreInfo(card, attr.sensor)}">


### PR DESCRIPTION
## Problem

Fixes #287. With `bars_per_row: 1`, units of measurement (`%`, `°C`, …) never display next to the bars, even with `hide_units: false`, regardless of `display_type` (compact or full).

## Root cause

`bars_per_row: 1` applies the `width-100` full-width layout class. Two CSS rules in `styles.ts` (`.attribute.tooltip.width-100 .header` and `.width-100 .header`) hard-set `display: none` on the `.header` element — which contains the value+unit. This predates the `hide_units` option and unconditionally overrode it. The TypeScript already gates header rendering correctly via `showUnits = !(hide_units ?? isCompact)`, so the element was emitted but CSS-hidden.

This is **not** the same as #248, which was the `@media (max-width: 600px)` viewport rule (left intact).

## Fix

- Remove both `.width-100 .header { display: none }` rules → header visibility is now governed solely by the `showUnits` gate (single source of truth).
- Add a `has-units` marker class (applied only when full-width **and** units are shown) and narrow the green bar to `70%` under it, leaving room for the value/unit. The wide `90%` bar is preserved when units are hidden (compact default) — no regression for that layout.

## Verification

- `npm run test` → 129/129 pass; lint + build clean.
- ⚠️ The bug is CSS-only (not evaluated by vitest/jsdom), so no automated test guards it — visual confirmation with `bars_per_row: 1` + `hide_units: false` is the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)