### PR TITLE
chore: release 2026.6.2-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.6.1",
+  "version": "2026.6.2-beta1",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
Beta release **2026.6.2-beta1**.

## What's new
- Fix #287: value/unit now display next to full-width bars (`bars_per_row: 1`) when `hide_units: false`, regardless of `display_type`. Previously the full-width layout always hid them.

Merging triggers the Auto Release workflow (build artifact + pre-release tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)