### PR TITLE
ci: native GitHub release notes + PR-label categories; add CONTRIBUTING.md

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# Configures GitHub's native release-notes generator (used by the Auto Release
+# workflow via `generate_release_notes: true`). PRs are bucketed by their labels;
+# label every PR so it lands in the right category. Unlabeled PRs fall into
+# "Other Changes". See CONTRIBUTING.md.
+changelog:
+  categories:
+    - title: 🚀 Features & Enhancements
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧹 Maintenance & CI
+      labels:
+        - dependencies
+        - github_actions
+        - ci
+        - chore
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,15 +100,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true' && steps.check_build.outputs.changed == 'true'
 
-      - name: "🗝️ Get previous release version"
-        id: last_release
-        run: |
-          LAST_TAG=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // empty')
-          echo "tag_name=${LAST_TAG}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
-
       - name: "🏷️ Create new tag"
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"
@@ -118,22 +109,14 @@ jobs:
           message: "Version ${{ env.COMPONENT_VERSION }}"
         if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
 
-      - name: "🗒️ Generate release changelog"
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sinceTag: ${{ steps.last_release.outputs.tag_name }}
-          headerLabel: "# Notable changes since ${{ steps.last_release.outputs.tag_name }}"
-          stripGeneratorNotice: true
-          output: RELEASE_CHANGELOG.md
-        if: steps.check_package.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
-
+      # GitHub's native release notes: auto-detects the previous tag (so a beta's
+      # notes don't span back to the last stable) and buckets PRs by label per
+      # .github/release.yml. Replaces the raw changelog-generator dump.
       - name: "👍 Create Stable release"
         uses: softprops/action-gh-release@v3
         with:
           prerelease: false
-          body_path: RELEASE_CHANGELOG.md
+          generate_release_notes: true
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
           files: |
@@ -145,7 +128,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           prerelease: true
-          body_path: RELEASE_CHANGELOG.md
+          generate_release_notes: true
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
           files: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for helping improve the **Lovelace Flower Card**! This guide covers the
+pull-request workflow and the **PR labels** that drive our release notes.
+
+## Development
+
+This is a TypeScript Lovelace card bundled with webpack.
+
+```bash
+npm ci              # install dependencies
+npm test            # run the vitest suite
+npm run lint        # eslint
+npm run build       # lint + webpack → flower-card.js (+ .gz)
+```
+
+> **Do not commit rebuilt `flower-card.js` / `flower-card.js.gz` in a feature PR.**
+> The **Auto Release** workflow rebuilds and commits the bundle at release time
+> (it opens and auto-merges a `build/v<version>` PR with the artifact). Change the
+> TypeScript sources under `src/`; leave the built files to CI.
+
+## Pull requests
+
+- Branch from `main`, open your PR against `main`.
+- CI (**Test & Lint**) must pass.
+- Add tests for new behavior and bug fixes.
+
+## PR labels (please add one)
+
+Release notes are generated automatically from **merged-PR labels** (GitHub's
+native generator, configured in [`.github/release.yml`](.github/release.yml)).
+Add a label so your change lands in the right section of the changelog:
+
+| Label | Release-notes section |
+|-------|-----------------------|
+| `enhancement` or `feature` | 🚀 Features & Enhancements |
+| `bug` or `fix` | 🐛 Bug Fixes |
+| `documentation` | 📚 Documentation |
+| `dependencies`, `github_actions`, `ci`, `chore` | 🧹 Maintenance & CI |
+| _(no label)_ | Other Changes |
+
+Pick the single label that best describes the PR's primary intent. Unlabeled PRs
+still appear under **Other Changes**, but a label makes the changelog readable.
+
+### For automated agents (Claude Code, etc.)
+
+When you open a PR, apply the matching label in the same step, e.g.:
+
+```bash
+gh pr edit <number> --add-label enhancement   # or bug / documentation / dependencies ...
+```
+
+## Releases (maintainers)
+
+Releases are automated. Bump the version in **`package.json`** on `main`; on the
+next green **Test & Lint** run the **Auto Release** workflow rebuilds
+`flower-card.js`, tags `v<version>`, and publishes a GitHub release (prerelease
+when the version contains `beta`) with the bundle attached and notes categorized
+from the merged-PR labels. Version format: `YYYY.M.P` (stable) or `YYYY.M.P-betaN`.


### PR DESCRIPTION
Mirrors the release-notes improvement done for the plant integration.

### Release CI
- Replace `heinrichreimer/github-changelog-generator` (raw closed-issues + merged-PRs dump) with GitHub's **native release notes** (`generate_release_notes: true` on the existing `softprops/action-gh-release` steps — bundle attachment and the build/artifact flow are unchanged).
  - Auto-detects the correct **previous tag**, so a beta's notes no longer span back to the last stable.
  - Buckets merged PRs by **label** per the new `.github/release.yml`.
- Drops the now-unused `last_release` + changelog-generator steps.

### Docs
- New **CONTRIBUTING.md**: dev workflow (npm/vitest/webpack), the label→section table, a note that built `flower-card.js` is regenerated by CI (don't commit it manually), and the release process.

### Note
Categorization keys off **PR labels**; this repo's PRs aren't consistently labeled yet, so early releases show a flat list under *Other Changes* until labels are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)