### PR TITLE
docs: polish water-plant badge automation example

### DIFF
--- a/EXTRA_BADGES.md
+++ b/EXTRA_BADGES.md
@@ -171,36 +171,30 @@ extra_badges:
   - entity: input_button.water_plant
 ```
 
-**Step 3:** Create an automation for the button press:
-Using UI, go to Settings > Automation & scenes > Automation > Create automation
+**Step 3:** Create an automation for the button press.
+
+> **Note:** Clicking an entity badge opens its more-info dialog. For an `input_button`, press the button in that dialog to run the automation — badges don't fire entities directly.
+
+Using the UI, go to **Settings → Automations & scenes → Automations → Create automation**, switch to YAML mode, and paste:
+
 ```yaml
 alias: Water plant when button pressed
-description: ""
 triggers:
   - trigger: state
-    entity_id:
-      - input_button.water_plant
-conditions: []
+    entity_id: input_button.water_plant
 actions:
   - action: switch.turn_on
-    metadata: {}
     target:
       entity_id: switch.plant_water_pump
-    data: {}
-  - delay:
-      hours: 0
-      minutes: 0
-      seconds: 25
-      milliseconds: 0
+  - delay: "00:00:30"
   - action: switch.turn_off
-    metadata: {}
     target:
       entity_id: switch.plant_water_pump
-    data: {}
 mode: single
-
 ```
-It is also possible to write your automations directly inside configuration.yaml on hacs
+
+Or add it directly in `configuration.yaml`:
+
 ```yaml
 automation:
   - alias: "Water plant when button pressed"


### PR DESCRIPTION
Follow-up cleanup to #299 (merged).

## What
- **Deduplicate** the two near-identical automations into one clean UI-editor example plus the `configuration.yaml` form.
- **Strip the raw UI-export noise** (`metadata: {}`, `data: {}`, `milliseconds: 0`, `description: ""`) so the example is readable.
- **Align the delay** to 30s across both snippets (was 25s vs 30s).
- **Fix phrasing**: "directly inside configuration.yaml on hacs" → "directly in `configuration.yaml`".
- **Clarify badge behavior**: clicking an entity badge opens its more-info dialog — for an `input_button` you press the button there to run the automation; badges don't fire entities directly. This addresses the question @effectpears raised on #299.

Docs-only, no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)