### PR TITLE
feat: care info badge — care details in a popup (#305)

### DIFF
--- a/EXTRA_BADGES.md
+++ b/EXTRA_BADGES.md
@@ -18,6 +18,7 @@ By default, only the icon is displayed. Hovering shows a tooltip with the entity
   - [📋 Attribute Badge](#-attribute-badge)
   - [🏷️ Static Icon/Text Badge](#️-static-icontext-badge)
   - [🔲 Action Button Badge](#-action-button-badge)
+  - [🌿 Care Info Badge](#-care-info-badge)
   - [🧩 Combined Example](#-combined-example)
 
 ---
@@ -34,6 +35,9 @@ By default, only the icon is displayed. Hovering shows a tooltip with the entity
 | `color_on` | string | Icon color when binary_sensor is "on" (default: primary color) |
 | `color_off` | string | Icon color when binary_sensor is "off" (default: disabled color) |
 | `show_state` | boolean | Show the entity's state value next to the icon (default: `false`) |
+| `type` | string | Badge type discriminator. Set to `care_info` for the care popup badge. |
+| `fields` | string[] | (`care_info`) Care fields shown in the popup. Default: all care fields. |
+| `title` | string | (`care_info`) Dialog heading. Default: `Care`. |
 
 ---
 
@@ -215,6 +219,37 @@ This lets you control plant-related devices (pumps, grow lights, etc.) directly 
 
 ---
 
+## 🌿 Care Info Badge
+
+Show the plant's care information in a popup dialog instead of inline on the card — keeps the card uncluttered while care details stay one tap away. Independent of the inline [Care Info](README.md) (`show_care`) block: you can show a short teaser inline and the full set in the popup.
+
+Minimal — the popup shows **all** available care fields:
+
+```yaml
+extra_badges:
+  - type: care_info
+```
+
+Customized — curate the fields, icon, color, and dialog title:
+
+```yaml
+extra_badges:
+  - type: care_info
+    fields:
+      - care_watering
+      - care_sunlight
+      - care_soil
+    icon: mdi:sprout        # default: mdi:sprout
+    color: green            # default: theme secondary text color
+    title: Plant Care       # default: "Care"
+```
+
+Available `fields` values: `care_watering`, `care_sunlight`, `care_soil`, `care_pruning`, `care_fertilization`. Only fields the plant actually provides are shown; an explicit empty list (`fields: []`) shows nothing.
+
+Tapping the badge opens a modal dialog with the selected care text. The badge is fully independent of the inline `show_care` setting.
+
+---
+
 ## 🧩 Combined Example
 
 ```yaml
@@ -231,4 +266,6 @@ extra_badges:
   - text: Kitchen
     icon: mdi:silverware-fork-knife
   - entity: input_button.water_plant
+  - type: care_info
+    icon: mdi:sprout
 ```

--- a/docs/superpowers/plans/2026-07-27-care-info-badge.md
+++ b/docs/superpowers/plans/2026-07-27-care-info-badge.md
@@ -1,0 +1,481 @@
+# Care Info Badge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `extra_badges` entry `type: care_info` that renders a badge which opens the plant's care info in an `ha-dialog` popup on tap, independent of the inline care block.
+
+**Architecture:** Push all decision logic into pure, exported helpers in `src/utils/attributes.ts` (this repo unit-tests pure logic only). Rendering functions consume those helpers. The card (`FlowerCard`, a `LitElement`) gains its first `@state` for dialog open/fields/title and renders a native `ha-dialog` on demand. Care-item markup is extracted once and reused by both the inline block and the popup.
+
+**Tech Stack:** TypeScript, Lit (LitElement + `lit/decorators.js`), vitest (jsdom), eslint.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-care-info-badge-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include these:
+
+- **Never run `npm run build` / `npm run dev` / webpack.** They regenerate `flower-card.js` and `flower-card.js.gz`. Those built artifacts must **NOT** be committed — CI's Auto Release rebuilds them. If they appear in `git status`, do not stage them.
+- **Branch:** `feature/care-info-badge` (already created, based on merged `origin/main`). Do not switch branches.
+- **Testing convention (repo-wide):** unit-test **pure exported functions only** — never instantiate the LitElement, never assert on Lit `TemplateResult`/DOM. See `tests/care.test.ts` and `tests/flower-card.test.ts` for the established style. Rendering/markup changes are verified by `npx tsc --noEmit`, `npm run lint`, and the existing regression suite staying green.
+- **Per-task verification commands:**
+  - Tests: `npx vitest run <file>` (and `npx vitest run` for the full suite)
+  - Types: `npx tsc --noEmit` (must exit 0)
+  - Lint: `npm run lint` (must pass)
+- **Behavior:** the care badge is opt-in; it does **not** suppress or alter the inline `renderCareInfo` block (both may render). No changes to the visual editor (`getConfigForm`) — `extra_badges` is YAML-only.
+- **Defaults:** badge icon `mdi:sprout`; badge/dialog color `var(--secondary-text-color)`; dialog title `"Care"`; popup fields = all `careFields` values (in `careFields` order) when `fields` is omitted (`undefined`). An explicitly empty `fields: []` shows nothing (documented).
+- **`ha-dialog`** is an ambient Home Assistant custom element — do not import it.
+
+---
+
+### Task 1: Config types + pure care-badge logic
+
+**Files:**
+- Modify: `src/types/flower-card-types.ts` (extend `ExtraBadge`)
+- Modify: `src/utils/attributes.ts` (add constants + pure helpers)
+- Test: `tests/care-badge.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `careFields` from `src/utils/constants.ts`; `ExtraBadge`, `CareEntry` types.
+- Produces (all exported from `src/utils/attributes.ts`):
+  - `CARE_BADGE_TYPE = 'care_info'` (string const)
+  - `isCareBadge(badge: ExtraBadge): boolean`
+  - `resolveCareBadgeFields(badge: ExtraBadge): string[]`
+  - `computeCareDialogState(badge: ExtraBadge): { open: boolean; fields: string[]; title: string }`
+  - `careBadgeVisual(badge: ExtraBadge): { icon: string; color: string; tip: string }`
+
+- [ ] **Step 1: Extend the `ExtraBadge` interface**
+
+In `src/types/flower-card-types.ts`, add three optional fields to the top of the `ExtraBadge` interface (keep existing fields):
+
+```ts
+export interface ExtraBadge {
+    type?: string;        // Badge type discriminator (e.g. "care_info")
+    fields?: string[];    // care_info: care fields shown in the popup (default: all)
+    title?: string;       // care_info: dialog heading (default: "Care")
+    entity?: string;      // Entity ID for sensor/binary_sensor
+    attribute?: string;   // Entity attribute to display instead of state (e.g., "last_changed")
+    icon?: string;        // Icon to display (default: entity's icon or mdi:information)
+    color?: string;       // Color for regular sensors/text
+    color_on?: string;    // Color when binary_sensor is "on" (default: green)
+    color_off?: string;   // Color when binary_sensor is "off" (default: grey)
+    text?: string;        // Static text to display (alternative to entity)
+    show_state?: boolean; // Show state value next to icon (default: false)
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/care-badge.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  CARE_BADGE_TYPE,
+  isCareBadge,
+  resolveCareBadgeFields,
+  computeCareDialogState,
+  careBadgeVisual,
+} from '../src/utils/attributes';
+import { careFields } from '../src/utils/constants';
+import { ExtraBadge } from '../src/types/flower-card-types';
+
+const ALL = careFields.map(f => f.value);
+
+describe('care badge logic', () => {
+  describe('isCareBadge', () => {
+    it('is true only for type care_info', () => {
+      expect(isCareBadge({ type: CARE_BADGE_TYPE })).toBe(true);
+      expect(isCareBadge({ type: 'care_info' })).toBe(true);
+      expect(isCareBadge({ entity: 'sensor.x' })).toBe(false);
+      expect(isCareBadge({ text: 'Hi' })).toBe(false);
+      expect(isCareBadge({})).toBe(false);
+    });
+  });
+
+  describe('resolveCareBadgeFields', () => {
+    it('defaults to all care fields when fields omitted', () => {
+      expect(resolveCareBadgeFields({ type: CARE_BADGE_TYPE })).toEqual(ALL);
+    });
+    it('returns the given subset when fields provided', () => {
+      const badge: ExtraBadge = { type: CARE_BADGE_TYPE, fields: ['care_soil', 'care_watering'] };
+      expect(resolveCareBadgeFields(badge)).toEqual(['care_soil', 'care_watering']);
+    });
+    it('passes an explicit empty array through (shows nothing)', () => {
+      expect(resolveCareBadgeFields({ type: CARE_BADGE_TYPE, fields: [] })).toEqual([]);
+    });
+  });
+
+  describe('computeCareDialogState', () => {
+    it('opens with all fields and default title', () => {
+      expect(computeCareDialogState({ type: CARE_BADGE_TYPE })).toEqual({
+        open: true, fields: ALL, title: 'Care',
+      });
+    });
+    it('honors fields and title overrides', () => {
+      const badge: ExtraBadge = { type: CARE_BADGE_TYPE, fields: ['care_watering'], title: 'Plant Care' };
+      expect(computeCareDialogState(badge)).toEqual({
+        open: true, fields: ['care_watering'], title: 'Plant Care',
+      });
+    });
+  });
+
+  describe('careBadgeVisual', () => {
+    it('uses default icon, color and tip', () => {
+      expect(careBadgeVisual({ type: CARE_BADGE_TYPE })).toEqual({
+        icon: 'mdi:sprout', color: 'var(--secondary-text-color)', tip: 'Care',
+      });
+    });
+    it('honors icon, color and title overrides', () => {
+      const badge: ExtraBadge = { type: CARE_BADGE_TYPE, icon: 'mdi:leaf', color: 'green', title: 'Care Guide' };
+      expect(careBadgeVisual(badge)).toEqual({
+        icon: 'mdi:leaf', color: 'green', tip: 'Care Guide',
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/care-badge.test.ts`
+Expected: FAIL — imports `CARE_BADGE_TYPE`, `isCareBadge`, etc. do not exist yet.
+
+- [ ] **Step 4: Implement the helpers**
+
+In `src/utils/attributes.ts`, add the following near the existing `selectCareInfo` / `renderCareInfo` functions (they reference `careFields` and `ExtraBadge`, both already imported in this file):
+
+```ts
+/** Discriminator value for the care-info badge (extra_badges: - type: care_info). */
+export const CARE_BADGE_TYPE = 'care_info';
+
+/** True when an extra_badges item is the care-info badge. */
+export const isCareBadge = (badge: ExtraBadge): boolean => badge.type === CARE_BADGE_TYPE;
+
+/** Popup field list for a care badge: its `fields`, or ALL care fields when omitted. */
+export const resolveCareBadgeFields = (badge: ExtraBadge): string[] =>
+    badge.fields ?? careFields.map(f => f.value);
+
+/** Open-dialog state derived from a tapped care badge. */
+export const computeCareDialogState = (
+    badge: ExtraBadge,
+): { open: boolean; fields: string[]; title: string } => ({
+    open: true,
+    fields: resolveCareBadgeFields(badge),
+    title: badge.title ?? 'Care',
+});
+
+/** Badge icon/color/tooltip for a care badge, with defaults. */
+export const careBadgeVisual = (
+    badge: ExtraBadge,
+): { icon: string; color: string; tip: string } => ({
+    icon: badge.icon ?? 'mdi:sprout',
+    color: badge.color ?? 'var(--secondary-text-color)',
+    tip: badge.title ?? 'Care',
+});
+```
+
+- [ ] **Step 5: Run tests, types, lint**
+
+Run: `npx vitest run tests/care-badge.test.ts` → Expected: PASS (all cases)
+Run: `npx tsc --noEmit` → Expected: exit 0
+Run: `npm run lint` → Expected: pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/flower-card-types.ts src/utils/attributes.ts tests/care-badge.test.ts
+git commit -m "feat: care-badge config types and pure logic helpers"
+```
+
+---
+
+### Task 2: Care-item DRY extraction + badge rendering
+
+**Files:**
+- Modify: `src/utils/attributes.ts` (add `renderCareItems`, refactor `renderCareInfo`, add `renderCareBadge`, add `care_info` branch to `renderExtraBadge`)
+
+**Interfaces:**
+- Consumes: `isCareBadge`, `careBadgeVisual` (Task 1); `selectCareInfo`, `CareEntry` (existing); `FlowerCard` type (existing param type of `renderExtraBadge`); `card.openCareDialog(badge)` (added in Task 3 — a public method `openCareDialog(badge: ExtraBadge): void`).
+- Produces: `renderCareItems(entries: CareEntry[]): TemplateResult`; `renderCareBadge(card: FlowerCard, badge: ExtraBadge): TemplateResult`.
+
+**Note on ordering:** `renderCareBadge`'s click handler calls `card.openCareDialog(badge)`, which is defined in Task 3. TypeScript resolves this only after Task 3 adds the method. Therefore **run `npx tsc --noEmit` for this task only after Task 3**, OR (preferred) implement Task 2 and Task 3 back-to-back and typecheck once at the end of Task 3. Within Task 2, the regression check is the existing suite; the full typecheck gate lives at the end of Task 3. This is called out so the reviewer does not treat the deferred typecheck as a defect.
+
+- [ ] **Step 1: Extract `renderCareItems` and refactor `renderCareInfo`**
+
+In `src/utils/attributes.ts`, add the shared item renderer and rewrite `renderCareInfo` to use it. The rendered markup must be **byte-for-byte equivalent** to today's output (same `.care-info` wrapper, same `.care-item`/`.care-heading`/`.care-text` structure).
+
+```ts
+export const renderCareItems = (entries: CareEntry[]): TemplateResult => html`
+    ${entries.map(entry => html`
+        <div class="care-item">
+            <div class="care-heading">
+                <ha-icon .icon="${entry.icon}"></ha-icon>
+                <span>${entry.label}</span>
+            </div>
+            <div class="care-text">${entry.text}</div>
+        </div>
+    `)}
+`;
+
+export const renderCareInfo = (card: FlowerCard): TemplateResult => {
+    const config = card.config;
+    if (!config) return html``;
+
+    const entity = config.entity;
+    const attributes = entity ? card._hass.states[entity]?.attributes : undefined;
+    const entries = selectCareInfo(attributes, config.show_care);
+    if (entries.length === 0) return html``;
+
+    return html`
+        <div class="care-info">
+            ${renderCareItems(entries)}
+        </div>
+    `;
+};
+```
+
+- [ ] **Step 2: Add `renderCareBadge`**
+
+Add near `renderExtraBadge` in `src/utils/attributes.ts`:
+
+```ts
+export const renderCareBadge = (card: FlowerCard, badge: ExtraBadge): TemplateResult => {
+    const { icon, color, tip } = careBadgeVisual(badge);
+    return html`
+        <div class="extra-badge tooltip" @click="${(e: Event) => { e.stopPropagation(); card.openCareDialog(badge); }}">
+            <div class="tip" style="text-align:center;">${tip}</div>
+            <ha-icon .icon="${icon}" style="color: ${color}"></ha-icon>
+        </div>
+    `;
+};
+```
+
+- [ ] **Step 3: Route care badges in `renderExtraBadge`**
+
+At the very top of `renderExtraBadge` (before the existing text/entity/icon branches), add:
+
+```ts
+    // Care info badge - opens a dialog with care details
+    if (isCareBadge(badge)) {
+        return renderCareBadge(card, badge);
+    }
+```
+
+- [ ] **Step 4: Verify existing suite + lint still pass**
+
+Run: `npx vitest run` → Expected: PASS (existing `care.test.ts` and all others unchanged — proves the `renderCareInfo` refactor preserved selection behavior)
+Run: `npm run lint` → Expected: pass
+(Defer `npx tsc --noEmit` to the end of Task 3 per the note above.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/attributes.ts
+git commit -m "feat: render care badge and extract shared care-item markup"
+```
+
+---
+
+### Task 3: Dialog state, open/close, and styles
+
+**Files:**
+- Modify: `src/flower-card.ts` (imports, `@state` fields, `openCareDialog`, `_closeCareDialog`, `renderCareDialog`, mount in `render()`)
+- Modify: `src/styles.ts` (dialog padding + empty-state rules)
+
+**Interfaces:**
+- Consumes: `computeCareDialogState`, `selectCareInfo`, `renderCareItems` (Tasks 1–2); `ExtraBadge` type; `careFields` (already imported).
+- Produces: `FlowerCard.openCareDialog(badge: ExtraBadge): void` (public — called by `renderCareBadge`).
+
+- [ ] **Step 1: Update imports in `src/flower-card.ts`**
+
+Line 2 — add `state`:
+```ts
+import { customElement, property, state } from 'lit/decorators.js';
+```
+Line 5 — add `ExtraBadge`:
+```ts
+import { DisplayType, EntitySuggestion, ExtraBadge, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
+```
+Line 7 — add `computeCareDialogState`, `renderCareItems`, and `selectCareInfo`:
+```ts
+import { computeCareDialogState, renderAttributes, renderBattery, renderCareInfo, renderCareItems, renderExtraBadges, selectCareInfo } from './utils/attributes';
+```
+
+- [ ] **Step 2: Add reactive state fields**
+
+Immediately after the existing `@property() config?: FlowerCardConfig;` (around line 45), add:
+
+```ts
+    @state() private _careDialogOpen = false;
+    @state() private _careDialogFields: string[] = [];
+    @state() private _careDialogTitle = 'Care';
+```
+
+- [ ] **Step 3: Add open/close methods**
+
+Add these methods to the `FlowerCard` class (e.g. just before `render()`):
+
+```ts
+    openCareDialog(badge: ExtraBadge): void {
+        const { open, fields, title } = computeCareDialogState(badge);
+        this._careDialogFields = fields;
+        this._careDialogTitle = title;
+        this._careDialogOpen = open;
+    }
+
+    private _closeCareDialog(): void {
+        this._careDialogOpen = false;
+    }
+```
+
+(`computeCareDialogState`, `selectCareInfo`, and `renderCareItems` were already added to the line 7 import in Step 1.)
+
+- [ ] **Step 4: Add `renderCareDialog`**
+
+Add this method to the `FlowerCard` class:
+
+```ts
+    private renderCareDialog(): HTMLTemplateResult {
+        const entity = this.config?.entity;
+        const attributes = entity ? this._hass?.states[entity]?.attributes : undefined;
+        const entries = selectCareInfo(attributes, this._careDialogFields);
+        return html`
+            <ha-dialog open heading="${this._careDialogTitle}" @closed="${() => this._closeCareDialog()}">
+                ${entries.length > 0
+                    ? html`<div class="care-info care-info--dialog">${renderCareItems(entries)}</div>`
+                    : html`<div class="care-info-empty">No care information available.</div>`}
+            </ha-dialog>
+        `;
+    }
+```
+
+- [ ] **Step 5: Mount the dialog in `render()`**
+
+In `render()`, insert the dialog as the last node of the returned template — after `</ha-card>` (currently line 250) and before the closing backtick:
+
+```ts
+            </ha-card>
+            ${this._careDialogOpen ? this.renderCareDialog() : html``}
+            `;
+```
+
+- [ ] **Step 6: Add styles**
+
+In `src/styles.ts`, insert after the `.care-text { ... }` rule (ends at the `}` on the line before the closing `` `; `` of the `css` template):
+
+```css
+.care-info--dialog {
+  padding: 4px 4px 8px;
+}
+.care-info-empty {
+  padding: 8px 4px;
+  color: var(--secondary-text-color);
+}
+```
+
+- [ ] **Step 7: Full verification gate (Tasks 2 + 3 together)**
+
+Run: `npx tsc --noEmit` → Expected: exit 0 (now that `openCareDialog` exists, `renderCareBadge`'s call resolves)
+Run: `npx vitest run` → Expected: PASS (full suite, incl. `care-badge.test.ts`)
+Run: `npm run lint` → Expected: pass
+Run: `git status --porcelain` → confirm **no** `flower-card.js` / `flower-card.js.gz` are staged or modified. If webpack was never run, they will be untouched.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/flower-card.ts src/styles.ts
+git commit -m "feat: care-info dialog opened from the care badge"
+```
+
+---
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: `EXTRA_BADGES.md` (TOC entry, new section, combined example)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add a Table-of-Contents entry**
+
+In `EXTRA_BADGES.md`, in the `## 📑 Table of Contents` list, add a line for the new section immediately after the "Action Button Badge" entry:
+
+```md
+  - [🌿 Care Info Badge](#-care-info-badge)
+```
+
+- [ ] **Step 2: Add the badge to the Options table**
+
+In the `## ⚙️ Badge Options` table, add rows for the care-badge options (append after `show_state`):
+
+```md
+| `type` | string | Badge type discriminator. Set to `care_info` for the care popup badge. |
+| `fields` | string[] | (`care_info`) Care fields shown in the popup. Default: all care fields. |
+| `title` | string | (`care_info`) Dialog heading. Default: `Care`. |
+```
+
+- [ ] **Step 3: Add the "Care Info Badge" section**
+
+Add this section immediately before the `## 🧩 Combined Example` section:
+
+````md
+## 🌿 Care Info Badge
+
+Show the plant's care information in a popup dialog instead of inline on the card — keeps the card uncluttered while care details stay one tap away. Independent of the inline [Care Info](README.md) (`show_care`) block: you can show a short teaser inline and the full set in the popup.
+
+Minimal — the popup shows **all** available care fields:
+
+```yaml
+extra_badges:
+  - type: care_info
+```
+
+Customized — curate the fields, icon, color, and dialog title:
+
+```yaml
+extra_badges:
+  - type: care_info
+    fields:
+      - care_watering
+      - care_sunlight
+      - care_soil
+    icon: mdi:sprout        # default: mdi:sprout
+    color: green            # default: theme secondary text color
+    title: Plant Care       # default: "Care"
+```
+
+Available `fields` values: `care_watering`, `care_sunlight`, `care_soil`, `care_pruning`, `care_fertilization`. Only fields the plant actually provides are shown; an explicit empty list (`fields: []`) shows nothing.
+
+Tapping the badge opens a modal dialog with the selected care text. The badge is fully independent of the inline `show_care` setting.
+
+---
+````
+
+- [ ] **Step 4: Add to the Combined Example**
+
+In the `## 🧩 Combined Example` YAML block, add a care badge entry to `extra_badges`:
+
+```yaml
+  - type: care_info
+    icon: mdi:sprout
+```
+
+- [ ] **Step 5: Verify links and render**
+
+Confirm the new TOC anchor `#-care-info-badge` matches the heading `## 🌿 Care Info Badge` (GitHub lowercases, drops emoji, and hyphenates: `care-info-badge`). No build/test needed for docs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add EXTRA_BADGES.md
+git commit -m "docs: document the care_info badge in EXTRA_BADGES.md"
+```
+
+---
+
+## Post-implementation (controller / final review)
+
+- Full suite green: `npx vitest run`; types clean: `npx tsc --noEmit`; lint clean: `npm run lint`.
+- **Do not** run `npm run build`; confirm `flower-card.js` / `flower-card.js.gz` are **not** in the diff.
+- Open a PR to `main`, label it `enhancement` (and/or `feature`) so the release notes categorize it under 🚀 Features & Enhancements. Reference #305.
+- Version bump (`package.json`) is a **separate** release step, not part of this feature PR — a version bump is what triggers CI's Auto Release.

--- a/docs/superpowers/specs/2026-07-27-care-info-badge-design.md
+++ b/docs/superpowers/specs/2026-07-27-care-info-badge-design.md
@@ -1,0 +1,248 @@
+# Care Info Badge — Design
+
+**Status:** Approved (brainstorm 2026-07-27)
+
+**Goal:** Add an opt-in `extra_badges` entry, `type: care_info`, that renders a
+badge which opens the plant's care information in an `ha-dialog` popup when
+tapped. This lets users keep the card uncluttered while care details stay one
+click away — "some info in the card, more on click on the badge."
+
+Closes #305 (Feature request: allow care information to be folded).
+
+## Motivation
+
+Today care info renders as an always-visible `.care-info` block at the bottom
+of the card (`renderCareInfo`, driven by the `show_care` field list). #305 asks
+for a less cluttered view with care still one click away. Rather than folding
+the inline block, this design offers care as a **badge-triggered popup** — a
+cleaner separation that leaves the card body free while giving on-demand access
+to the full care detail.
+
+## Design principles
+
+- **Opt-in, no regressions.** Existing cards with inline `show_care` are
+  unchanged. The feature only activates when a `type: care_info` badge is added.
+- **Independent of inline care.** The popup does not replace or suppress the
+  inline block. Both can render. A user can show a small teaser inline via
+  `show_care` and the full set in the popup — that is the intended use.
+- **DRY.** The popup reuses the exact care-item markup and the existing
+  `selectCareInfo` selection logic. No parallel rendering path.
+- **YAML-only, consistent with all badges.** `extra_badges` is not in the visual
+  editor's `ha-form` schema today; the care badge follows suit. No editor work.
+
+## Config surface
+
+`extra_badges` items are objects. The care badge is discriminated by a new
+`type` field:
+
+```yaml
+extra_badges:
+  # minimal — popup shows ALL care fields the plant has
+  - type: care_info
+
+  # curated
+  - type: care_info
+    fields: [care_watering, care_sunlight, care_soil]  # subset, ordered by careFields
+    icon: mdi:sprout          # optional, default mdi:sprout
+    color: green              # optional, default var(--secondary-text-color)
+    title: "Plant Care"       # optional dialog heading, default "Care"
+```
+
+### `ExtraBadge` interface additions (`src/types/flower-card-types.ts`)
+
+```ts
+export interface ExtraBadge {
+    type?: string;        // NEW: badge-type discriminator, e.g. "care_info"
+    fields?: string[];    // NEW: (care_info) care fields for the popup; default = all
+    title?: string;       // NEW: (care_info) dialog heading; default "Care"
+    entity?: string;
+    attribute?: string;
+    icon?: string;        // reused: badge icon (care_info default mdi:sprout)
+    color?: string;       // reused: badge icon color
+    color_on?: string;
+    color_off?: string;
+    text?: string;
+    show_state?: boolean;
+}
+```
+
+Field semantics for `type: care_info`:
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `fields` | all `careFields` values | Which care fields appear in the popup, filtered to known care fields and to those with non-empty text on the entity. |
+| `icon` | `mdi:sprout` | Badge icon. |
+| `color` | `var(--secondary-text-color)` | Badge icon color. |
+| `title` | `"Care"` | `ha-dialog` heading. |
+
+`fields` is validated the same way inline `show_care` is: only values present in
+`careFields` (`care_watering`, `care_sunlight`, `care_soil`, `care_pruning`,
+`care_fertilization`) are honored; unknown values are ignored. Order follows
+`careFields`, matching inline behavior.
+
+## Rendering
+
+### 1. Reactive state (`src/flower-card.ts`)
+
+`FlowerCard` (a `LitElement`) gains its first component-local UI state:
+
+```ts
+@state() private _careDialogOpen = false;
+@state() private _careDialogFields?: string[];
+@state() private _careDialogTitle = "Care";
+```
+
+(Import `state` from `lit/decorators.js` alongside the existing decorators.)
+
+### 2. Badge click path (`src/utils/attributes.ts`)
+
+`renderExtraBadge` checks the care type **first**, before the existing
+text/entity/icon branches:
+
+```ts
+if (badge.type === 'care_info') {
+    return renderCareBadge(card, badge);
+}
+```
+
+`renderCareBadge` renders a standard `.extra-badge tooltip` with:
+- icon = `badge.icon || 'mdi:sprout'`
+- color = `badge.color || 'var(--secondary-text-color)'`
+- tooltip tip = `badge.title || 'Care'`
+- `@click` handler that calls a card method opening the dialog and stashing the
+  badge's field list + title:
+
+```ts
+@click="${(e: Event) => { e.stopPropagation(); card.openCareDialog(badge); }}"
+```
+
+`FlowerCard.openCareDialog(badge)` sets:
+```ts
+this._careDialogFields = badge.fields ?? careFields.map(f => f.value);
+this._careDialogTitle = badge.title ?? "Care";
+this._careDialogOpen = true;
+```
+
+The badge always renders (it does not depend on care content being present); if
+the plant has no matching care fields, the opened dialog simply shows an
+"empty" state (see §4).
+
+### 3. DRY care-item rendering (`src/utils/attributes.ts`)
+
+Extract the item list from today's `renderCareInfo` into a shared helper so both
+the inline block and the popup produce identical markup:
+
+```ts
+export const renderCareItems = (entries: CareEntry[]): TemplateResult => html`
+    ${entries.map(entry => html`
+        <div class="care-item">
+            <div class="care-heading">
+                <ha-icon .icon="${entry.icon}"></ha-icon>
+                <span>${entry.label}</span>
+            </div>
+            <div class="care-text">${entry.text}</div>
+        </div>
+    `)}
+`;
+```
+
+`renderCareInfo` (inline) becomes:
+```ts
+const entries = selectCareInfo(attributes, config.show_care);
+if (entries.length === 0) return html``;
+return html`<div class="care-info">${renderCareItems(entries)}</div>`;
+```
+
+Its observable output is unchanged (same `.care-info` wrapper + items).
+
+### 4. The dialog (`src/flower-card.ts`, end of `render()`)
+
+Rendered once, appended after the main card content, active only when open:
+
+```ts
+${this._careDialogOpen ? this.renderCareDialog() : html``}
+```
+
+`renderCareDialog()`:
+```ts
+const attributes = this.config?.entity
+    ? this._hass.states[this.config.entity]?.attributes
+    : undefined;
+const entries = selectCareInfo(attributes, this._careDialogFields);
+return html`
+    <ha-dialog open heading="${this._careDialogTitle}"
+        @closed="${() => { this._careDialogOpen = false; }}">
+        ${entries.length > 0
+            ? html`<div class="care-info care-info--dialog">${renderCareItems(entries)}</div>`
+            : html`<div class="care-info-empty">No care information available.</div>`}
+    </ha-dialog>
+`;
+```
+
+`ha-dialog` is an ambient Home Assistant custom element (globally registered by
+the frontend); it requires no import and provides the modal, backdrop,
+ESC-to-close, and accessibility behavior. `@closed` fires for backdrop click,
+ESC, and the close button — the single reset point.
+
+## Styling (`src/styles.ts`)
+
+Reuse `.care-info` / `.care-item` inside the dialog. Add minimal rules only if
+needed for dialog padding (e.g. `.care-info--dialog { padding: 4px 0; }`) and a
+muted `.care-info-empty`. No changes to existing selectors.
+
+## Interaction with `show_care`
+
+Fully independent:
+- Inline `.care-info` renders iff `show_care` lists fields with content (today's
+  behavior, untouched).
+- The badge popup renders `fields` (default all) regardless of `show_care`.
+- Both may show simultaneously — intended (teaser inline, full set in popup).
+
+## Editor
+
+No changes. `extra_badges` is YAML-only (not present in the `getConfigForm`
+`ha-form` schema); the care badge is configured in YAML like every other badge.
+The docs already state badges are YAML-only.
+
+## Documentation (`EXTRA_BADGES.md`)
+
+Add a "🌿 Care Info Badge" section and a Table-of-Contents entry. Document the
+`type`/`fields`/`icon`/`color`/`title` options, the default-all behavior, and
+that it is independent of inline `show_care`. Add a `- type: care_info` line to
+the Combined Example.
+
+## Testing (`vitest`)
+
+- `selectCareInfo` already covered for `show_care`; add cases proving the popup's
+  default-all list (`careFields.map(f => f.value)`) selects every field with
+  content, and that an explicit `fields` subset narrows correctly and ignores
+  unknown values.
+- `renderExtraBadge`: a `{ type: 'care_info' }` badge takes the care branch —
+  not the entity/text/icon branches — and renders a click handler; default icon
+  is `mdi:sprout`; `icon`/`color`/`title` overrides are honored.
+- `openCareDialog(badge)` sets `_careDialogOpen = true`, `_careDialogFields` to
+  `badge.fields ?? all`, and `_careDialogTitle` to `badge.title ?? "Care"`.
+- The dialog closes (`_careDialogOpen = false`) on the `@closed` event.
+- Popup content is independent of `show_care` (a badge with no `show_care`
+  configured still yields care entries).
+
+## Out of scope (YAGNI)
+
+- Remembering open/closed state across reloads or navigations.
+- A visual (GUI) editor for `extra_badges` / the care badge.
+- Per-field ordering beyond the existing `careFields` order.
+- Animations beyond what `ha-dialog` provides.
+
+## Files touched
+
+- `src/types/flower-card-types.ts` — `ExtraBadge` gains `type`, `fields`, `title`.
+- `src/utils/attributes.ts` — `renderCareItems` extraction; `renderCareBadge`;
+  `care_info` branch in `renderExtraBadge`.
+- `src/flower-card.ts` — `@state` fields; `openCareDialog`; `renderCareDialog`;
+  dialog mount in `render()`.
+- `src/styles.ts` — minimal dialog/empty-state rules.
+- `EXTRA_BADGES.md` — new section + TOC + combined example.
+- `tests/` — new vitest cases per above.
+
+Note: `flower-card.js` / `flower-card.js.gz` are build artifacts rebuilt by CI's
+Auto Release; they are **not** committed in this PR.

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -4,7 +4,7 @@ import { HomeAssistant } from 'custom-card-helpers';
 import { style } from './styles';
 import { DisplayType, EntitySuggestion, ExtraBadge, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
 import * as packageJson from '../package.json';
-import { computeCareDialogState, renderAttributes, renderBattery, renderCareInfo, renderCareItems, renderExtraBadges, selectCareInfo } from './utils/attributes';
+import { CARE_DIALOG_DEFAULT_TITLE, computeCareDialogState, renderAttributes, renderBattery, renderCareInfo, renderCareItems, renderExtraBadges, selectCareInfo } from './utils/attributes';
 import { CARD_NAME, careFields, default_show_bars, missingImage, plantAttributes } from './utils/constants';
 import { isMediaSourceUrl, moreInfo, resolveMediaSource } from './utils/utils';
 
@@ -45,7 +45,7 @@ export default class FlowerCard extends LitElement {
     @property() config?: FlowerCardConfig;
     @state() private _careDialogOpen = false;
     @state() private _careDialogFields: string[] = [];
-    @state() private _careDialogTitle = 'Care';
+    @state() private _careDialogTitle = CARE_DIALOG_DEFAULT_TITLE;
 
     private stateObj: HomeAssistantEntity | undefined;
     private previousFetchDate = 0;
@@ -242,6 +242,7 @@ export default class FlowerCard extends LitElement {
         if (!this.config || !this._hass) return html``;
 
         if (!this.stateObj) {
+            this._careDialogOpen = false;
             return html`
                 <hui-warning>
                 Entity not available: ${this.config.entity}

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -1,10 +1,10 @@
 import { CSSResult, HTMLTemplateResult, LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant } from 'custom-card-helpers';
 import { style } from './styles';
-import { DisplayType, EntitySuggestion, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
+import { DisplayType, EntitySuggestion, ExtraBadge, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
 import * as packageJson from '../package.json';
-import { renderAttributes, renderBattery, renderCareInfo, renderExtraBadges } from './utils/attributes';
+import { computeCareDialogState, renderAttributes, renderBattery, renderCareInfo, renderCareItems, renderExtraBadges, selectCareInfo } from './utils/attributes';
 import { CARD_NAME, careFields, default_show_bars, missingImage, plantAttributes } from './utils/constants';
 import { isMediaSourceUrl, moreInfo, resolveMediaSource } from './utils/utils';
 
@@ -43,6 +43,9 @@ export const getEntitySuggestion = (hass: HomeAssistant, entityId: string): Enti
 export default class FlowerCard extends LitElement {
     @property() _hass?: any;
     @property() config?: FlowerCardConfig;
+    @state() private _careDialogOpen = false;
+    @state() private _careDialogFields: string[] = [];
+    @state() private _careDialogTitle = 'Care';
 
     private stateObj: HomeAssistantEntity | undefined;
     private previousFetchDate = 0;
@@ -211,6 +214,30 @@ export default class FlowerCard extends LitElement {
         this.config = config;
     }
 
+    openCareDialog(badge: ExtraBadge): void {
+        const { open, fields, title } = computeCareDialogState(badge);
+        this._careDialogFields = fields;
+        this._careDialogTitle = title;
+        this._careDialogOpen = open;
+    }
+
+    private _closeCareDialog(): void {
+        this._careDialogOpen = false;
+    }
+
+    private renderCareDialog(): HTMLTemplateResult {
+        const entity = this.config?.entity;
+        const attributes = entity ? this._hass?.states[entity]?.attributes : undefined;
+        const entries = selectCareInfo(attributes, this._careDialogFields);
+        return html`
+            <ha-dialog open heading="${this._careDialogTitle}" @closed="${() => this._closeCareDialog()}">
+                ${entries.length > 0
+                    ? html`<div class="care-info care-info--dialog">${renderCareItems(entries)}</div>`
+                    : html`<div class="care-info-empty">No care information available.</div>`}
+            </ha-dialog>
+        `;
+    }
+
     render(): HTMLTemplateResult {
         if (!this.config || !this._hass) return html``;
 
@@ -248,6 +275,7 @@ export default class FlowerCard extends LitElement {
             ${renderAttributes(this)}
             ${renderCareInfo(this)}
             </ha-card>
+            ${this._careDialogOpen ? this.renderCareDialog() : html``}
             `;
     }
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -240,4 +240,11 @@ export const style = css`
   line-height: 1.4;
   color: var(--secondary-text-color);
 }
+.care-info--dialog {
+  padding: 4px 4px 8px;
+}
+.care-info-empty {
+  padding: 8px 4px;
+  color: var(--secondary-text-color);
+}
 `;

--- a/src/types/flower-card-types.ts
+++ b/src/types/flower-card-types.ts
@@ -2,6 +2,9 @@ import { LovelaceCardConfig } from "custom-card-helpers";
 import { HassEntity } from "home-assistant-js-websocket";
 
 export interface ExtraBadge {
+    type?: string;        // Badge type discriminator (e.g. "care_info")
+    fields?: string[];    // care_info: care fields shown in the popup (default: all)
+    title?: string;       // care_info: dialog heading (default: "Care")
     entity?: string;      // Entity ID for sensor/binary_sensor
     attribute?: string;   // Entity attribute to display instead of state (e.g., "last_changed")
     icon?: string;        // Icon to display (default: entity's icon or mdi:information)

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -31,6 +31,18 @@ export const selectCareInfo = (
             typeof entry.text === 'string' && entry.text.trim() !== '');
 };
 
+export const renderCareItems = (entries: CareEntry[]): TemplateResult => html`
+    ${entries.map(entry => html`
+        <div class="care-item">
+            <div class="care-heading">
+                <ha-icon .icon="${entry.icon}"></ha-icon>
+                <span>${entry.label}</span>
+            </div>
+            <div class="care-text">${entry.text}</div>
+        </div>
+    `)}
+`;
+
 export const renderCareInfo = (card: FlowerCard): TemplateResult => {
     const config = card.config;
     if (!config) return html``;
@@ -42,15 +54,7 @@ export const renderCareInfo = (card: FlowerCard): TemplateResult => {
 
     return html`
         <div class="care-info">
-            ${entries.map(entry => html`
-                <div class="care-item">
-                    <div class="care-heading">
-                        <ha-icon .icon="${entry.icon}"></ha-icon>
-                        <span>${entry.label}</span>
-                    </div>
-                    <div class="care-text">${entry.text}</div>
-                </div>
-            `)}
+            ${renderCareItems(entries)}
         </div>
     `;
 };
@@ -82,6 +86,16 @@ export const careBadgeVisual = (
     color: badge.color ?? 'var(--secondary-text-color)',
     tip: badge.title ?? 'Care',
 });
+
+export const renderCareBadge = (card: FlowerCard, badge: ExtraBadge): TemplateResult => {
+    const { icon, color, tip } = careBadgeVisual(badge);
+    return html`
+        <div class="extra-badge tooltip" @click="${(e: Event) => { e.stopPropagation(); card.openCareDialog(badge); }}">
+            <div class="tip" style="text-align:center;">${tip}</div>
+            <ha-icon .icon="${icon}" style="color: ${color}"></ha-icon>
+        </div>
+    `;
+};
 
 /**
  * Check if a unit indicates PPFD (not lux).
@@ -138,6 +152,11 @@ export const renderBattery = (card: FlowerCard) => {
 }
 
 export const renderExtraBadge = (card: FlowerCard, badge: ExtraBadge) => {
+    // Care info badge - opens a dialog with care details
+    if (isCareBadge(badge)) {
+        return renderCareBadge(card, badge);
+    }
+
     // Handle static text badge
     if (badge.text) {
         const hideIcon = badge.icon?.toLowerCase() === 'none';

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -55,6 +55,34 @@ export const renderCareInfo = (card: FlowerCard): TemplateResult => {
     `;
 };
 
+/** Discriminator value for the care-info badge (extra_badges: - type: care_info). */
+export const CARE_BADGE_TYPE = 'care_info';
+
+/** True when an extra_badges item is the care-info badge. */
+export const isCareBadge = (badge: ExtraBadge): boolean => badge.type === CARE_BADGE_TYPE;
+
+/** Popup field list for a care badge: its `fields`, or ALL care fields when omitted. */
+export const resolveCareBadgeFields = (badge: ExtraBadge): string[] =>
+    badge.fields ?? careFields.map(f => f.value);
+
+/** Open-dialog state derived from a tapped care badge. */
+export const computeCareDialogState = (
+    badge: ExtraBadge,
+): { open: boolean; fields: string[]; title: string } => ({
+    open: true,
+    fields: resolveCareBadgeFields(badge),
+    title: badge.title ?? 'Care',
+});
+
+/** Badge icon/color/tooltip for a care badge, with defaults. */
+export const careBadgeVisual = (
+    badge: ExtraBadge,
+): { icon: string; color: string; tip: string } => ({
+    icon: badge.icon ?? 'mdi:sprout',
+    color: badge.color ?? 'var(--secondary-text-color)',
+    tip: badge.title ?? 'Care',
+});
+
 /**
  * Check if a unit indicates PPFD (not lux).
  * Covers: µmol/s⋅m², μmol/s⋅m², mol/s⋅m², etc.

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -62,6 +62,9 @@ export const renderCareInfo = (card: FlowerCard): TemplateResult => {
 /** Discriminator value for the care-info badge (extra_badges: - type: care_info). */
 export const CARE_BADGE_TYPE = 'care_info';
 
+/** Default title for care dialog when badge title is undefined. */
+export const CARE_DIALOG_DEFAULT_TITLE = 'Care';
+
 /** True when an extra_badges item is the care-info badge. */
 export const isCareBadge = (badge: ExtraBadge): boolean => badge.type === CARE_BADGE_TYPE;
 
@@ -75,7 +78,7 @@ export const computeCareDialogState = (
 ): { open: boolean; fields: string[]; title: string } => ({
     open: true,
     fields: resolveCareBadgeFields(badge),
-    title: badge.title ?? 'Care',
+    title: badge.title ?? CARE_DIALOG_DEFAULT_TITLE,
 });
 
 /** Badge icon/color/tooltip for a care badge, with defaults. */
@@ -84,7 +87,7 @@ export const careBadgeVisual = (
 ): { icon: string; color: string; tip: string } => ({
     icon: badge.icon ?? 'mdi:sprout',
     color: badge.color ?? 'var(--secondary-text-color)',
-    tip: badge.title ?? 'Care',
+    tip: badge.title ?? CARE_DIALOG_DEFAULT_TITLE,
 });
 
 export const renderCareBadge = (card: FlowerCard, badge: ExtraBadge): TemplateResult => {

--- a/tests/care-badge.test.ts
+++ b/tests/care-badge.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CARE_BADGE_TYPE,
+  isCareBadge,
+  resolveCareBadgeFields,
+  computeCareDialogState,
+  careBadgeVisual,
+} from '../src/utils/attributes';
+import { careFields } from '../src/utils/constants';
+import { ExtraBadge } from '../src/types/flower-card-types';
+
+const ALL = careFields.map(f => f.value);
+
+describe('care badge logic', () => {
+  describe('isCareBadge', () => {
+    it('is true only for type care_info', () => {
+      expect(isCareBadge({ type: CARE_BADGE_TYPE })).toBe(true);
+      expect(isCareBadge({ type: 'care_info' })).toBe(true);
+      expect(isCareBadge({ entity: 'sensor.x' })).toBe(false);
+      expect(isCareBadge({ text: 'Hi' })).toBe(false);
+      expect(isCareBadge({})).toBe(false);
+    });
+  });
+
+  describe('resolveCareBadgeFields', () => {
+    it('defaults to all care fields when fields omitted', () => {
+      expect(resolveCareBadgeFields({ type: CARE_BADGE_TYPE })).toEqual(ALL);
+    });
+    it('returns the given subset when fields provided', () => {
+      const badge: ExtraBadge = { type: CARE_BADGE_TYPE, fields: ['care_soil', 'care_watering'] };
+      expect(resolveCareBadgeFields(badge)).toEqual(['care_soil', 'care_watering']);
+    });
+    it('passes an explicit empty array through (shows nothing)', () => {
+      expect(resolveCareBadgeFields({ type: CARE_BADGE_TYPE, fields: [] })).toEqual([]);
+    });
+  });
+
+  describe('computeCareDialogState', () => {
+    it('opens with all fields and default title', () => {
+      expect(computeCareDialogState({ type: CARE_BADGE_TYPE })).toEqual({
+        open: true, fields: ALL, title: 'Care',
+      });
+    });
+    it('honors fields and title overrides', () => {
+      const badge: ExtraBadge = { type: CARE_BADGE_TYPE, fields: ['care_watering'], title: 'Plant Care' };
+      expect(computeCareDialogState(badge)).toEqual({
+        open: true, fields: ['care_watering'], title: 'Plant Care',
+      });
+    });
+  });
+
+  describe('careBadgeVisual', () => {
+    it('uses default icon, color and tip', () => {
+      expect(careBadgeVisual({ type: CARE_BADGE_TYPE })).toEqual({
+        icon: 'mdi:sprout', color: 'var(--secondary-text-color)', tip: 'Care',
+      });
+    });
+    it('honors icon, color and title overrides', () => {
+      const badge: ExtraBadge = { type: CARE_BADGE_TYPE, icon: 'mdi:leaf', color: 'green', title: 'Care Guide' };
+      expect(careBadgeVisual(badge)).toEqual({
+        icon: 'mdi:leaf', color: 'green', tip: 'Care Guide',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #305.

## What
Adds an opt-in `extra_badges` entry, `type: care_info`, that renders a badge which opens the plant's care information in a native `ha-dialog` popup on tap — keeping the card uncluttered while care detail stays one click away. Fully **independent** of the inline `show_care` block, so you can show a short teaser inline and the full set in the popup.

```yaml
extra_badges:
  - type: care_info                    # popup shows ALL care fields (default)

  - type: care_info                    # or curate it
    fields: [care_watering, care_sunlight, care_soil]
    icon: mdi:sprout                   # default mdi:sprout
    color: green
    title: Plant Care                  # default "Care"
```

## How
- `ExtraBadge` gains `type` / `fields` / `title`; `renderExtraBadge` routes `care_info` first, before the text/entity/icon branches.
- Care-item markup extracted into a shared `renderCareItems` — reused by both the inline block and the dialog (DRY, single selection path via `selectCareInfo`).
- The card gains its first reactive `@state` (`_careDialogOpen`/`_careDialogFields`/`_careDialogTitle`); tapping the badge opens a native `ha-dialog`, closed via a single `@closed` reset point.
- Popup fields default to **all** care fields when `fields` is omitted; an explicit `fields: []` shows nothing.
- Docs: new "🌿 Care Info Badge" section + options table + combined example in `EXTRA_BADGES.md`.

## Notes
- Opt-in — existing cards are unchanged; no editor changes (`extra_badges` is YAML-only).
- No new dependency: `ha-dialog` is an ambient HA element.
- **Built `flower-card.js`/`.gz` intentionally NOT committed** — CI rebuilds on release.

## Tests
- New pure-logic unit tests for the config helpers (`tests/care-badge.test.ts`), matching the repo's test convention.
- Full suite **137/137**, `tsc --noEmit` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)