### PR TITLE
feat: tap thumbnail opens image lightbox — changes image-tap behavior (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Tap the plant's thumbnail to open the full-size image in a popup, with the plant
 
 > **Note:** This changed the previous behavior, where tapping the image opened more-info. Cards with no image or with `hide_image: true` are unaffected — tapping still opens more-info.
 
-No configuration is needed; the lightbox is enabled automatically whenever the card shows an image.
+No configuration is needed; the lightbox is enabled automatically whenever the card shows a real plant image (not the placeholder).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Lovelace card for displaying plant data from the [Plant Monitor](https://githu
   - [🌿 Care Info](#-care-info)
   - [🔋 Battery Sensor](#-battery-sensor)
   - [🏷️ Extra Badges](#️-extra-badges)
+  - [🔍 Image Lightbox](#-image-lightbox)
   - [🎨 Other Options](#-other-options)
   - [☕ Support](#-support)
 
@@ -225,6 +226,16 @@ For the full reference with all badge types and options, see **[EXTRA_BADGES.md]
 <img width="531" height="574" alt="image" src="https://github.com/user-attachments/assets/8452d48d-baf3-40f4-9979-fbb48860260d" />
 
 
+
+---
+
+## 🔍 Image Lightbox
+
+Tap the plant's thumbnail to open the full-size image in a popup, with the plant's name shown below it — handy for telling apart multiple plants of the same species that have different photos. Tap the plant **name** (or anywhere else in the header) to open the standard more-info dialog.
+
+> **Note:** This changed the previous behavior, where tapping the image opened more-info. Cards with no image or with `hide_image: true` are unaffected — tapping still opens more-info.
+
+No configuration is needed; the lightbox is enabled automatically whenever the card shows an image.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-27-image-lightbox.md
+++ b/docs/superpowers/plans/2026-07-27-image-lightbox.md
@@ -1,0 +1,282 @@
+# Thumbnail Image Lightbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tapping the plant thumbnail opens the full-size image in an `ha-dialog` lightbox with the plant's display name captioned; tapping the name still opens more-info.
+
+**Architecture:** Reuse the `@state` + `ha-dialog` pattern added for the care-info badge (#309). A pure `shouldEnableImageLightbox` helper (unit-tested) gates whether the image is tappable-to-lightbox; the LitElement holds an `_imageDialogOpen` state and renders the lightbox on demand. The header container's more-info handler is unchanged — the image's own click handler opens the lightbox and stops propagation only when a real image exists.
+
+**Tech Stack:** TypeScript, Lit (LitElement + `lit/decorators.js`), vitest (jsdom), eslint.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-image-lightbox-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include these:
+
+- **Never run `npm run build` / `npm run dev` / webpack.** They regenerate `flower-card.js` / `flower-card.js.gz`, which must **NOT** be committed. If they appear in `git status`, do not stage them.
+- **Branch:** `feature/image-lightbox` (already created, based on `origin/main` which includes #309). Do not switch branches.
+- **Testing convention (repo-wide):** unit-test **pure exported functions only** — never instantiate the LitElement, never assert on Lit `TemplateResult`/DOM. Rendering/state changes are verified by `npx tsc --noEmit`, `npm run lint`, and the existing regression suite staying green.
+- **Per-task verification commands:**
+  - Tests: `npx vitest run <file>` (and `npx vitest run` for the full suite)
+  - Types: `npx tsc --noEmit` (must exit 0)
+  - Lint: `npm run lint` (must pass)
+- **Behavior change (must be documented):** image taps previously opened more-info; they now open the lightbox. Task 3 documents this in the README. The PR title (controller, post-implementation) must explicitly signal the change — the repo has no CHANGELOG file; the changelog is GitHub native release notes generated from the PR title + label.
+- **Scope:** default behavior, no config toggle. Imageless / `hide_image` cards are unaffected (tap falls through to more-info). Caption is the display name only.
+
+---
+
+### Task 1: `shouldEnableImageLightbox` pure helper
+
+**Files:**
+- Modify: `src/utils/utils.ts` (add the helper)
+- Test: `tests/utils.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces: `shouldEnableImageLightbox(hideImage: boolean, resolvedImageUrl: string | undefined): boolean` (exported from `src/utils/utils.ts`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/utils.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { shouldEnableImageLightbox } from '../src/utils/utils';
+
+describe('shouldEnableImageLightbox', () => {
+  it('is true when not hidden and a real URL is present', () => {
+    expect(shouldEnableImageLightbox(false, 'https://example.com/plant.jpg')).toBe(true);
+    expect(shouldEnableImageLightbox(false, '/local/plant.jpg')).toBe(true);
+  });
+  it('is false when the image is hidden, even with a URL', () => {
+    expect(shouldEnableImageLightbox(true, 'https://example.com/plant.jpg')).toBe(false);
+  });
+  it('is false when there is no resolved URL', () => {
+    expect(shouldEnableImageLightbox(false, undefined)).toBe(false);
+    expect(shouldEnableImageLightbox(false, '')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/utils.test.ts`
+Expected: FAIL — `shouldEnableImageLightbox` is not exported yet.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/utils/utils.ts`, append after the existing `resolveMediaSource` export:
+
+```ts
+/** True when the thumbnail should open a lightbox (real image present and not hidden). */
+export const shouldEnableImageLightbox = (
+    hideImage: boolean,
+    resolvedImageUrl: string | undefined,
+): boolean => !hideImage && !!resolvedImageUrl;
+```
+
+- [ ] **Step 4: Run tests, types, lint**
+
+Run: `npx vitest run tests/utils.test.ts` → Expected: PASS (3 cases)
+Run: `npx tsc --noEmit` → Expected: exit 0
+Run: `npm run lint` → Expected: pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/utils.ts tests/utils.test.ts
+git commit -m "feat: shouldEnableImageLightbox pure helper"
+```
+
+---
+
+### Task 2: Lightbox state, dialog, image wiring, and styles
+
+**Files:**
+- Modify: `src/flower-card.ts` (import, `@state`, methods, img wiring, stale-flag guard, dialog mount)
+- Modify: `src/styles.ts` (lightbox + caption + `.has-lightbox` rules)
+
+**Interfaces:**
+- Consumes: `shouldEnableImageLightbox` (Task 1); existing `this._resolvedImageUrl`, `this.stateObj`, `missingImage`, `moreInfo`, the `@state` pattern from #309.
+- Produces: `FlowerCard.openImageDialog(): void` (public, for symmetry with `openCareDialog`; called only from the image `@click` in this file).
+
+- [ ] **Step 1: Import the helper**
+
+In `src/flower-card.ts` line 9, add `shouldEnableImageLightbox`:
+```ts
+import { isMediaSourceUrl, moreInfo, resolveMediaSource, shouldEnableImageLightbox } from './utils/utils';
+```
+
+- [ ] **Step 2: Add the reactive state field**
+
+After the existing `@state() private _careDialogTitle = CARE_DIALOG_DEFAULT_TITLE;` (line 48), add:
+```ts
+    @state() private _imageDialogOpen = false;
+```
+
+- [ ] **Step 3: Add open/close/render methods**
+
+Add these methods next to the care-dialog methods (e.g. immediately after `renderCareDialog()` ends, before `render()`):
+
+```ts
+    openImageDialog(): void {
+        this._imageDialogOpen = true;
+    }
+
+    private _closeImageDialog(): void {
+        this._imageDialogOpen = false;
+    }
+
+    private renderImageDialog(): HTMLTemplateResult {
+        const displayName = this.config?.name || this.stateObj?.attributes.friendly_name || '';
+        return html`
+            <ha-dialog open @closed="${() => this._closeImageDialog()}">
+                <div class="image-dialog">
+                    <img src="${this._resolvedImageUrl}" alt="${displayName}">
+                    ${displayName ? html`<div class="image-dialog-caption">${displayName}</div>` : ''}
+                </div>
+            </ha-dialog>
+        `;
+    }
+```
+
+- [ ] **Step 4: Reset the flag on entity-unavailable**
+
+In `render()`, the `!this.stateObj` branch already resets `_careDialogOpen` (line 245). Add the image flag beside it:
+```ts
+        if (!this.stateObj) {
+            this._careDialogOpen = false;
+            this._imageDialogOpen = false;
+            return html`
+                <hui-warning>
+                Entity not available: ${this.config.entity}
+                </hui-warning>
+              `;
+        }
+```
+
+- [ ] **Step 5: Compute the lightbox flag**
+
+In `render()`, immediately after `const hideImage = this.config.hide_image ?? false;` (line 257), add:
+```ts
+        const imageLightbox = shouldEnableImageLightbox(hideImage, this._resolvedImageUrl);
+```
+
+- [ ] **Step 6: Wire the image click**
+
+Replace the current image line (line 266):
+```ts
+                ${!hideImage ? html`<img src="${this._resolvedImageUrl || missingImage}">` : ''}
+```
+with:
+```ts
+                ${!hideImage ? html`<img
+                    src="${this._resolvedImageUrl || missingImage}"
+                    class="${imageLightbox ? 'has-lightbox' : ''}"
+                    @click="${(e: Event) => {
+                        if (!imageLightbox) return;
+                        e.stopPropagation();
+                        this.openImageDialog();
+                    }}">` : ''}
+```
+When `imageLightbox` is false the handler returns without `stopPropagation`, so the header container's `@click` (more-info) still fires — preserving today's behavior for imageless/placeholder cards.
+
+- [ ] **Step 7: Mount the dialog**
+
+After the care-dialog mount (line 279), add the image-dialog mount:
+```ts
+            ${this._careDialogOpen ? this.renderCareDialog() : html``}
+            ${this._imageDialogOpen ? this.renderImageDialog() : html``}
+```
+
+- [ ] **Step 8: Add styles**
+
+In `src/styles.ts`, insert after the `.care-info-empty { ... }` block (the last rule before the closing `` `; `` of the `css` template):
+```css
+.has-lightbox {
+  cursor: pointer;
+}
+.image-dialog {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.image-dialog img {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+}
+.image-dialog-caption {
+  margin-top: 8px;
+  text-align: center;
+  color: var(--primary-text-color);
+  font-weight: 500;
+}
+```
+
+- [ ] **Step 9: Verification gate**
+
+Run: `npx tsc --noEmit` → Expected: exit 0
+Run: `npx vitest run` → Expected: full suite passes (existing + Task 1's `tests/utils.test.ts`)
+Run: `npm run lint` → Expected: pass
+Run: `git status --porcelain` → confirm no `flower-card.js` / `flower-card.js.gz`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/flower-card.ts src/styles.ts
+git commit -m "feat: open image lightbox on thumbnail tap"
+```
+
+---
+
+### Task 3: Document the behavior change (README)
+
+**Files:**
+- Modify: `README.md` (new section + TOC entry)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add a Table-of-Contents entry**
+
+In `README.md`'s `## 📑 Table of Contents` list, add an entry between the "Extra Badges" and "Other Options" lines:
+```md
+  - [🔍 Image Lightbox](#-image-lightbox)
+```
+
+- [ ] **Step 2: Add the "Image Lightbox" section**
+
+Insert this section immediately before `## 🎨 Other Options`:
+
+````md
+## 🔍 Image Lightbox
+
+Tap the plant's thumbnail to open the full-size image in a popup, with the plant's name shown below it — handy for telling apart multiple plants of the same species that have different photos. Tap the plant **name** (or anywhere else in the header) to open the standard more-info dialog.
+
+> **Note:** This changed the previous behavior, where tapping the image opened more-info. Cards with no image or with `hide_image: true` are unaffected — tapping still opens more-info.
+
+No configuration is needed; the lightbox is enabled automatically whenever the card shows an image.
+
+---
+````
+
+- [ ] **Step 3: Verify the TOC anchor**
+
+Confirm the TOC anchor `#-image-lightbox` matches the heading `## 🔍 Image Lightbox` (GitHub lowercases, drops the emoji, hyphenates spaces → `-image-lightbox`), consistent with sibling entries like `[🌿 Care Info](#-care-info)`. No build/test needed for docs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document thumbnail image lightbox behavior change"
+```
+
+---
+
+## Post-implementation (controller / final review)
+
+- Full suite green: `npx vitest run`; types clean: `npx tsc --noEmit`; lint clean: `npm run lint`.
+- **Do not** run `npm run build`; confirm `flower-card.js` / `flower-card.js.gz` are **not** in the diff.
+- Open a PR to `main` whose **title explicitly signals the behavior change** (it becomes the changelog line via native release notes), e.g. `feat: tap thumbnail opens image lightbox (changes image-tap behavior) (#247)`. Label it `enhancement` (and/or `feature`). Reference #247 and call out the behavior change prominently in the PR body.
+- Version bump (`package.json`) is a **separate** release step, not part of this feature PR.

--- a/docs/superpowers/specs/2026-07-27-image-lightbox-design.md
+++ b/docs/superpowers/specs/2026-07-27-image-lightbox-design.md
@@ -1,0 +1,159 @@
+# Thumbnail Image Lightbox — Design
+
+**Status:** Approved (brainstorm 2026-07-27)
+
+**Goal:** Tapping the plant thumbnail opens the full-size image in a lightbox (`ha-dialog`) with the plant's display name captioned below it. Tapping the name (or elsewhere in the header) still opens more-info. Closes #247.
+
+## Motivation
+
+#247: users with several plants of the same species but different photos want to see the image clearly to tell them apart. Today the entire header — image included — opens the standard more-info dialog, so there is no way to view the image on its own. This adds a dedicated image lightbox, reusing the `@state` + `ha-dialog` pattern introduced for the care-info badge (#309).
+
+## Behavior
+
+- **Default, no config.** Tapping the thumbnail image opens the lightbox; tapping the name / species / empty header area opens more-info.
+- **This is a behavior change:** image taps previously opened more-info. It must be documented (see Documentation below).
+- **Lightbox content:** the full-size image, centered, `object-fit: contain`, capped height (~80vh), with the plant's **display name** (`config.name || friendly_name`) as a caption below. Close via backdrop click / ESC / close button (`ha-dialog`'s `@closed`).
+- **Guard — only a real image is tappable-to-lightbox.** The lightbox is wired only when a real resolved image exists (`_resolvedImageUrl` truthy and `hide_image` false). When the image is missing (the `missingImage` placeholder is shown) or hidden, tapping falls through to the header's more-info handler exactly as today.
+
+## Implementation
+
+### Trigger wiring (`src/flower-card.ts`, `render()` ~line 266)
+
+Keep the header container's existing `@click` → `moreInfo(...)` unchanged. In `render()`, compute the lightbox-enable flag once via the pure helper, then use it for both the class and the click guard:
+
+```ts
+const imageLightbox = shouldEnableImageLightbox(hideImage, this._resolvedImageUrl);
+```
+
+On the `<img>`, add a click handler that opens the lightbox and stops propagation — active only when `imageLightbox` is true:
+
+```ts
+${!hideImage ? html`<img
+    src="${this._resolvedImageUrl || missingImage}"
+    class="${imageLightbox ? 'has-lightbox' : ''}"
+    @click="${(e: Event) => {
+        if (!imageLightbox) return;   // placeholder: let it fall through to more-info
+        e.stopPropagation();
+        this.openImageDialog();
+    }}">` : ''}
+```
+
+When `imageLightbox` is false the handler returns without stopping propagation, so the container's more-info handler still fires — preserving today's behavior for imageless cards.
+
+### Reactive state + methods (`src/flower-card.ts`)
+
+Mirror the care-dialog pattern added in #309:
+
+```ts
+@state() private _imageDialogOpen = false;
+
+openImageDialog(): void {
+    this._imageDialogOpen = true;
+}
+
+private _closeImageDialog(): void {
+    this._imageDialogOpen = false;
+}
+
+private renderImageDialog(): HTMLTemplateResult {
+    const displayName = this.config?.name || this.stateObj?.attributes.friendly_name || '';
+    return html`
+        <ha-dialog open @closed="${() => this._closeImageDialog()}">
+            <div class="image-dialog">
+                <img src="${this._resolvedImageUrl}" alt="${displayName}">
+                ${displayName ? html`<div class="image-dialog-caption">${displayName}</div>` : ''}
+            </div>
+        </ha-dialog>
+    `;
+}
+```
+
+### Stale-flag guard (`src/flower-card.ts`, `render()` early return)
+
+The `!stateObj` early-return branch already resets `_careDialogOpen` (from #309). Add the image flag alongside it so an unavailable-entity transition can't leave a ghost lightbox:
+
+```ts
+if (!this.stateObj) {
+    this._careDialogOpen = false;
+    this._imageDialogOpen = false;
+    return html` ... hui-warning ... `;
+}
+```
+
+### Mount (`src/flower-card.ts`, end of `render()`)
+
+Alongside the existing care-dialog mount, after `</ha-card>`:
+
+```ts
+${this._careDialogOpen ? this.renderCareDialog() : html``}
+${this._imageDialogOpen ? this.renderImageDialog() : html``}
+```
+
+### Guard helper (pure, testable) (`src/utils/utils.ts`)
+
+Per the repo's "unit-test pure logic only" convention, extract the lightbox-enable predicate so it can be tested without the DOM:
+
+```ts
+/** True when the thumbnail should open a lightbox (real image present and not hidden). */
+export const shouldEnableImageLightbox = (
+    hideImage: boolean,
+    resolvedImageUrl: string | undefined,
+): boolean => !hideImage && !!resolvedImageUrl;
+```
+
+Use it in `render()` for the class assignment / handler guard so the render path and the tested logic agree.
+
+### Styles (`src/styles.ts`)
+
+```css
+.has-lightbox {
+  cursor: pointer;
+}
+.image-dialog {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.image-dialog img {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+}
+.image-dialog-caption {
+  margin-top: 8px;
+  text-align: center;
+  color: var(--primary-text-color);
+  font-weight: 500;
+}
+```
+
+## Documentation (required deliverables)
+
+The behavior change must be documented in both places:
+
+1. **README.md** — add a short "Image Lightbox" subsection (under "🎨 Other Options" or as its own `##` section) plus a Table-of-Contents entry, stating: tapping the thumbnail opens a full-size image with the plant name; tapping the name opens plant info; and noting this changed the previous behavior where tapping the image opened more-info. Imageless / `hide_image` cards are unaffected.
+
+2. **Changelog** — this repo has **no CHANGELOG file**; the changelog is GitHub's native release notes generated from PR titles + labels (`.github/release.yml`). Therefore the **PR title must explicitly convey the behavior change** (it becomes the changelog line), e.g. `feat: tap thumbnail opens image lightbox (changes image-tap behavior) (#247)`, and the PR body must call out the change prominently. No CHANGELOG file is to be created (it would contradict the native-notes convention).
+
+## Testing (`vitest`, pure logic only)
+
+- `shouldEnableImageLightbox`: true only when `hideImage` is false AND `resolvedImageUrl` is a non-empty string; false when hidden, when URL is `undefined`, or when URL is `''`.
+- The display-name caption uses the same `config.name || friendly_name` resolution already covered by the existing "display name logic" test in `tests/flower-card.test.ts`; no new test needed for it beyond what exists.
+- Dialog open/close and the click wiring are DOM/LitElement behavior — not unit-tested, consistent with #309 and the repo convention.
+
+## Out of scope (YAGNI)
+
+- Zoom / pan / carousel / multiple images.
+- Config to toggle the behavior (it is the new default).
+- Caption content beyond the display name (no species, no attributes).
+- Any change to imageless-card behavior.
+
+## Files touched
+
+- `src/flower-card.ts` — `@state` field, `openImageDialog`/`_closeImageDialog`/`renderImageDialog`, img click wiring, stale-flag guard, dialog mount, use of `shouldEnableImageLightbox`.
+- `src/utils/utils.ts` — `shouldEnableImageLightbox` helper.
+- `src/styles.ts` — lightbox + caption + `.has-lightbox` rules.
+- `README.md` — Image Lightbox section + TOC entry.
+- `tests/` — `shouldEnableImageLightbox` unit tests.
+
+Note: `flower-card.js` / `flower-card.js.gz` are build artifacts rebuilt by CI's Auto Release; they are **not** committed in this PR.

--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -6,7 +6,7 @@ import { DisplayType, EntitySuggestion, ExtraBadge, FlowerCardConfig, HomeAssist
 import * as packageJson from '../package.json';
 import { CARE_DIALOG_DEFAULT_TITLE, computeCareDialogState, renderAttributes, renderBattery, renderCareInfo, renderCareItems, renderExtraBadges, selectCareInfo } from './utils/attributes';
 import { CARD_NAME, careFields, default_show_bars, missingImage, plantAttributes } from './utils/constants';
-import { isMediaSourceUrl, moreInfo, resolveMediaSource } from './utils/utils';
+import { isMediaSourceUrl, moreInfo, resolveMediaSource, shouldEnableImageLightbox } from './utils/utils';
 
 console.info(
     `%c FLOWER-CARD %c ${packageJson.version}`,
@@ -46,6 +46,7 @@ export default class FlowerCard extends LitElement {
     @state() private _careDialogOpen = false;
     @state() private _careDialogFields: string[] = [];
     @state() private _careDialogTitle = CARE_DIALOG_DEFAULT_TITLE;
+    @state() private _imageDialogOpen = false;
 
     private stateObj: HomeAssistantEntity | undefined;
     private previousFetchDate = 0;
@@ -238,11 +239,32 @@ export default class FlowerCard extends LitElement {
         `;
     }
 
+    openImageDialog(): void {
+        this._imageDialogOpen = true;
+    }
+
+    private _closeImageDialog(): void {
+        this._imageDialogOpen = false;
+    }
+
+    private renderImageDialog(): HTMLTemplateResult {
+        const displayName = this.config?.name || this.stateObj?.attributes.friendly_name || '';
+        return html`
+            <ha-dialog open @closed="${() => this._closeImageDialog()}">
+                <div class="image-dialog">
+                    <img src="${this._resolvedImageUrl}" alt="${displayName}">
+                    ${displayName ? html`<div class="image-dialog-caption">${displayName}</div>` : ''}
+                </div>
+            </ha-dialog>
+        `;
+    }
+
     render(): HTMLTemplateResult {
         if (!this.config || !this._hass) return html``;
 
         if (!this.stateObj) {
             this._careDialogOpen = false;
+            this._imageDialogOpen = false;
             return html`
                 <hui-warning>
                 Entity not available: ${this.config.entity}
@@ -255,6 +277,7 @@ export default class FlowerCard extends LitElement {
         const displayName = this.config.name || stateObj.attributes.friendly_name;
         const hideSpecies = this.config.hide_species ?? false;
         const hideImage = this.config.hide_image ?? false;
+        const imageLightbox = shouldEnableImageLightbox(hideImage, this._resolvedImageUrl);
         const headerCssClass = this.config.display_type === DisplayType.Compact ? "header-compact" : "header";
         const haCardCssClass = (this.config.display_type === DisplayType.Compact || hideImage) ? "" : "card-margin-top";
         const noImageClass = hideImage ? " no-image" : "";
@@ -263,7 +286,14 @@ export default class FlowerCard extends LitElement {
             <ha-card class="${haCardCssClass}">
             <div class="${headerCssClass}${noImageClass}" @click="${() =>
                 moreInfo(this, stateObj.entity_id)}">
-                ${!hideImage ? html`<img src="${this._resolvedImageUrl || missingImage}">` : ''}
+                ${!hideImage ? html`<img
+                    src="${this._resolvedImageUrl || missingImage}"
+                    class="${imageLightbox ? 'has-lightbox' : ''}"
+                    @click="${(e: Event) => {
+                        if (!imageLightbox) return;
+                        e.stopPropagation();
+                        this.openImageDialog();
+                    }}">` : ''}
                 <span id="name"> ${displayName} <ha-icon .icon="mdi:${stateObj.state.toLowerCase() == "problem"
                 ? "alert-circle-outline"
                 : ""
@@ -277,6 +307,7 @@ export default class FlowerCard extends LitElement {
             ${renderCareInfo(this)}
             </ha-card>
             ${this._careDialogOpen ? this.renderCareDialog() : html``}
+            ${this._imageDialogOpen ? this.renderImageDialog() : html``}
             `;
     }
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -247,4 +247,23 @@ export const style = css`
   padding: 8px 4px;
   color: var(--secondary-text-color);
 }
+.has-lightbox {
+  cursor: pointer;
+}
+.image-dialog {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.image-dialog img {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+}
+.image-dialog-caption {
+  margin-top: 8px;
+  text-align: center;
+  color: var(--primary-text-color);
+  font-weight: 500;
+}
 `;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -41,3 +41,9 @@ export const resolveMediaSource = async (
         return ""; // Return empty string on failure, will fall back to missingImage
     }
 };
+
+/** True when the thumbnail should open a lightbox (real image present and not hidden). */
+export const shouldEnableImageLightbox = (
+    hideImage: boolean,
+    resolvedImageUrl: string | undefined,
+): boolean => !hideImage && !!resolvedImageUrl;

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { shouldEnableImageLightbox } from '../src/utils/utils';
+
+describe('shouldEnableImageLightbox', () => {
+  it('is true when not hidden and a real URL is present', () => {
+    expect(shouldEnableImageLightbox(false, 'https://example.com/plant.jpg')).toBe(true);
+    expect(shouldEnableImageLightbox(false, '/local/plant.jpg')).toBe(true);
+  });
+  it('is false when the image is hidden, even with a URL', () => {
+    expect(shouldEnableImageLightbox(true, 'https://example.com/plant.jpg')).toBe(false);
+  });
+  it('is false when there is no resolved URL', () => {
+    expect(shouldEnableImageLightbox(false, undefined)).toBe(false);
+    expect(shouldEnableImageLightbox(false, '')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #247.

## What
Tapping the plant thumbnail now opens the full-size image in a popup (`ha-dialog`) with the plant's name captioned below — handy for telling apart multiple plants of the same species that have different photos. Tapping the **name** (or elsewhere in the header) still opens the standard more-info dialog.

## ⚠️ Behavior change
Previously, tapping the image opened more-info. It now opens the image lightbox. Cards with **no image** or `hide_image: true` are unaffected — tapping still opens more-info. No configuration needed. This is documented in the README (new "🔍 Image Lightbox" section) and signaled in this PR title for the release notes.

## How
- New pure helper `shouldEnableImageLightbox(hideImage, resolvedImageUrl)` gates whether the image is tappable-to-lightbox (real resolved image + not hidden).
- Reuses the `@state` + `ha-dialog` pattern from the care-info badge (#309): `_imageDialogOpen`, `openImageDialog`/`renderImageDialog`, single `@closed` reset, plus the stale-flag guard in the `!stateObj` branch.
- The header container's `@click` (more-info) is unchanged; the `<img>`'s own `@click` calls `stopPropagation()` and opens the lightbox **only** when enabled — otherwise it falls through to more-info, preserving today's behavior for imageless/placeholder cards.
- Lightbox image uses `object-fit: contain`, `max-height: 80vh`; close via backdrop/ESC.

## Notes
- No new dependency: `ha-dialog` is an ambient HA element.
- **Built `flower-card.js`/`.gz` intentionally NOT committed** — CI rebuilds on release.

## Tests
- New pure-logic unit tests for the helper (`tests/utils.test.ts`).
- Full suite **140/140**, `tsc --noEmit` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)