### PR TITLE
release: 2026.7.0 (stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.7.0-beta1",
+  "version": "2026.7.0",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
Promote `2026.7.0-beta1` → stable **2026.7.0**.

Features since the last stable (2026.6.1):
- 🌿 **Care-info badge** (#309, closes #305) — care info in an `ha-dialog` popup via `extra_badges: - type: care_info`
- 🔍 **Image lightbox** (#310, closes #247) — tap the thumbnail to open the full-size image (⚠️ changes image-tap behavior; imageless/`hide_image` cards unaffected)

Version bump only; CI builds `flower-card.js`, tags `v2026.7.0`, and publishes the stable release.