### PR TITLE
ci: gate Test & Lint on PRs and push-to-main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,16 @@
 name: "Test & Lint"
 
 on:
+  # PRs to main are tested via pull_request; push runs only on main (which the
+  # Auto Release workflow keys on). Previously this ran on every push to every
+  # branch and had no pull_request trigger, so PRs weren't gated on their own
+  # event and unrelated branch pushes ran the full job.
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 # Least-privilege: this workflow only checks out and builds.
 permissions:


### PR DESCRIPTION
Previously `Test & Lint` ran on **every push to every branch** with **no `pull_request` trigger**. So unrelated branch pushes ran the full job, and PRs weren't gated on their own event.

- Scope `push` to `main` (which the **Auto Release** workflow keys on).
- Add a `pull_request` trigger for PRs to `main`.

Result: one run per PR, one on merge-to-main (which still triggers releases). Matches the same change in homeassistant-plant and home-assistant-openplantbook.