### PR TITLE
feat(i18n): add translations for config labels and care info

### DIFF
--- a/src/flower-card.ts
+++ b/src/flower-card.ts
@@ -5,7 +5,8 @@ import { style } from './styles';
 import { DisplayType, EntitySuggestion, ExtraBadge, FlowerCardConfig, HomeAssistantEntity, PlantInfo } from './types/flower-card-types';
 import * as packageJson from '../package.json';
 import { CARE_DIALOG_DEFAULT_TITLE, computeCareDialogState, renderAttributes, renderBattery, renderCareInfo, renderCareItems, renderExtraBadges, selectCareInfo } from './utils/attributes';
-import { CARD_NAME, careFields, default_show_bars, missingImage, plantAttributes } from './utils/constants';
+import { CARD_NAME, default_show_bars, getCareFields, getPlantAttributes, missingImage } from './utils/constants';
+import { getHassLanguage, getTranslation } from './utils/translations';
 import { isMediaSourceUrl, moreInfo, resolveMediaSource, shouldEnableImageLightbox } from './utils/utils';
 
 console.info(
@@ -13,6 +14,11 @@ console.info(
     'color: cyan; background: black; font-weight: bold;',
     'color: darkblue; background: white; font-weight: bold;'
 );
+
+const getConfigFormLanguage = (): string => {
+    if (typeof document === 'undefined') return 'en';
+    return document.documentElement?.lang || 'en';
+};
 
 // Suggests flower-card in Home Assistant's card picker when a plant entity is
 // selected (HA 2026.6+). Returns null for any non-plant entity so the card only
@@ -89,6 +95,7 @@ export default class FlowerCard extends LitElement {
     }
 
     static getConfigForm() {
+        const language = getConfigFormLanguage();
         return {
             schema: [
                 {
@@ -107,14 +114,14 @@ export default class FlowerCard extends LitElement {
                 {
                     type: "expandable",
                     name: "",
-                    title: "Bars",
+                    title: getTranslation('settings_bars', language),
                     schema: [
                         {
                             name: "show_bars",
                             selector: {
                                 select: {
                                     multiple: true,
-                                    options: plantAttributes
+                                    options: getPlantAttributes(language)
                                 }
                             }
                         }
@@ -123,14 +130,14 @@ export default class FlowerCard extends LitElement {
                 {
                     type: "expandable",
                     name: "",
-                    title: "Care Info",
+                    title: getTranslation('settings_care_info', language),
                     schema: [
                         {
                             name: "show_care",
                             selector: {
                                 select: {
                                     multiple: true,
-                                    options: careFields
+                                    options: getCareFields(language)
                                 }
                             }
                         }
@@ -139,15 +146,15 @@ export default class FlowerCard extends LitElement {
                 {
                     type: "expandable",
                     name: "",
-                    title: "Appearance",
+                    title: getTranslation('settings_appearance', language),
                     schema: [
                         {
                             name: "display_type",
                             selector: {
                                 select: {
                                     options: [
-                                        { value: "full", label: "Full" },
-                                        { value: "compact", label: "Compact" }
+                                        { value: "full", label: getTranslation('settings_full', language) },
+                                        { value: "compact", label: getTranslation('settings_compact', language) }
                                     ]
                                 }
                             }
@@ -169,15 +176,15 @@ export default class FlowerCard extends LitElement {
             ],
             computeLabel: (schema: { name: string }) => {
                 const labels: Record<string, string> = {
-                    entity: "Entity",
-                    name: "Display Name",
-                    display_type: "Display Type",
-                    battery_sensor: "Battery Sensor",
-                    show_bars: "Show Bars",
-                    show_care: "Show Care Info",
-                    hide_species: "Hide Species",
-                    hide_image: "Hide Image",
-                    hide_units: "Hide Units"
+                    entity: getTranslation('settings_entity', language),
+                    name: getTranslation('settings_display_name', language),
+                    display_type: getTranslation('settings_display_type', language),
+                    battery_sensor: getTranslation('settings_battery_sensor', language),
+                    show_bars: getTranslation('settings_show_bars', language),
+                    show_care: getTranslation('settings_show_care_info', language),
+                    hide_species: getTranslation('settings_hide_species', language),
+                    hide_image: getTranslation('settings_hide_image', language),
+                    hide_units: getTranslation('settings_hide_units', language)
                 };
                 return labels[schema.name] || schema.name;
             }
@@ -229,12 +236,13 @@ export default class FlowerCard extends LitElement {
     private renderCareDialog(): HTMLTemplateResult {
         const entity = this.config?.entity;
         const attributes = entity ? this._hass?.states[entity]?.attributes : undefined;
-        const entries = selectCareInfo(attributes, this._careDialogFields);
+        const language = getHassLanguage(this._hass);
+        const entries = selectCareInfo(attributes, this._careDialogFields, language);
         return html`
-            <ha-dialog open heading="${this._careDialogTitle}" @closed="${() => this._closeCareDialog()}">
+            <ha-dialog open heading="${this._careDialogTitle || getTranslation('care', language)}" @closed="${() => this._closeCareDialog()}">
                 ${entries.length > 0
                     ? html`<div class="care-info care-info--dialog">${renderCareItems(entries)}</div>`
-                    : html`<div class="care-info-empty">No care information available.</div>`}
+                    : html`<div class="care-info-empty">${getTranslation('no_care_info', language)}</div>`}
             </ha-dialog>
         `;
     }

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -1,7 +1,8 @@
 import { DisplayType, DisplayedAttribute, DisplayedAttributes, ExtraBadge, Limits } from "../types/flower-card-types";
 import { TemplateResult, html } from "lit";
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { careFields, careIcons, default_show_bars } from "./constants";
+import { careFields, careIcons, default_show_bars, getCareFields } from "./constants";
+import { getHassLanguage, getTranslation } from "./translations";
 import { moreInfo } from "./utils";
 import FlowerCard from "../flower-card";
 
@@ -17,9 +18,10 @@ export interface CareEntry {
 export const selectCareInfo = (
     attributes: Record<string, unknown> | undefined,
     showCare: string[] | undefined,
+    language = 'en',
 ): CareEntry[] => {
     if (!attributes || !showCare || showCare.length === 0) return [];
-    return careFields
+    return getCareFields(language)
         .filter(field => showCare.includes(field.value))
         .map(field => ({
             key: field.value,
@@ -49,7 +51,7 @@ export const renderCareInfo = (card: FlowerCard): TemplateResult => {
 
     const entity = config.entity;
     const attributes = entity ? card._hass.states[entity]?.attributes : undefined;
-    const entries = selectCareInfo(attributes, config.show_care);
+    const entries = selectCareInfo(attributes, config.show_care, getHassLanguage(card._hass));
     if (entries.length === 0) return html``;
 
     return html`
@@ -84,14 +86,15 @@ export const computeCareDialogState = (
 /** Badge icon/color/tooltip for a care badge, with defaults. */
 export const careBadgeVisual = (
     badge: ExtraBadge,
+    language = 'en',
 ): { icon: string; color: string; tip: string } => ({
     icon: badge.icon ?? 'mdi:sprout',
     color: badge.color ?? 'var(--secondary-text-color)',
-    tip: badge.title ?? CARE_DIALOG_DEFAULT_TITLE,
+    tip: badge.title ?? getTranslation('care', language),
 });
 
 export const renderCareBadge = (card: FlowerCard, badge: ExtraBadge): TemplateResult => {
-    const { icon, color, tip } = careBadgeVisual(badge);
+    const { icon, color, tip } = careBadgeVisual(badge, getHassLanguage(card._hass));
     return html`
         <div class="extra-badge tooltip" @click="${(e: Event) => { e.stopPropagation(); card.openCareDialog(badge); }}">
             <div class="tip" style="text-align:center;">${tip}</div>
@@ -366,7 +369,8 @@ export const renderAttribute = (card: FlowerCard, attr: DisplayedAttribute) => {
     const pct = useLinear
         ? 100 * Math.max(0, Math.min(1, (val - min) / (max - min)))
         : 100 * Math.max(0, Math.min(1, (Math.log(val) - Math.log(min)) / (Math.log(max) - Math.log(min))));
-    const toolTipText = aval ? `${attr.name}: ${val} ${unitTooltip}<br>(${min} ~ ${max} ${unitTooltip})` : card._hass.localize('state.default.unavailable');
+    const translatedName = getTranslation(attr.name, getHassLanguage(card._hass));
+    const toolTipText = aval ? `${translatedName}: ${val} ${unitTooltip}<br>(${min} ~ ${max} ${unitTooltip})` : card._hass.localize('state.default.unavailable');
     const label = (attr.name === 'dli' || attr.name === 'dli_24h') ? '<math style="display: inline-grid;" xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mfrac><mrow><mn>mol</mn></mrow><mrow><mn>d</mn><mn>⋅</mn><msup><mn>m</mn><mn>2</mn></msup></mrow></mfrac></mrow></math>' : unitTooltip
     // Determine settings with explicit overrides taking precedence over display_type defaults
     const isCompact = card.config?.display_type === DisplayType.Compact;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,6 +4,8 @@ export interface DropdownOption {
     value: string;
 }
 
+import { getTranslation } from './translations';
+
 export const CARD_NAME = "flower-card";
 
 export const default_show_bars = [
@@ -17,26 +19,30 @@ export const default_show_bars = [
 
 export const missingImage = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaWRZTWlkIG1lZXQiIGZvY3VzYWJsZT0iZmFsc2UiIHJvbGU9ImltZyIgYXJpYS1oaWRkZW49InRydWUiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgICAgIDxnPgogICAgICA8IS0tP2xpdCQ0MTM0MjMxNjkkLS0+PHBhdGggZD0iTTMsMTNBOSw5IDAgMCwwIDEyLDIyQzEyLDE3IDcuOTcsMTMgMywxM00xMiw1LjVBMi41LDIuNSAwIDAsMSAxNC41LDhBMi41LDIuNSAwIDAsMSAxMiwxMC41QTIuNSwyLjUgMCAwLDEgOS41LDhBMi41LDIuNSAwIDAsMSAxMiw1LjVNNS42LDEwLjI1QTIuNSwyLjUgMCAwLDAgOC4xLDEyLjc1QzguNjMsMTIuNzUgOS4xMiwxMi41OCA5LjUsMTIuMzFDOS41LDEyLjM3IDkuNSwxMi40MyA5LjUsMTIuNUEyLjUsMi41IDAgMCwwIDEyLDE1QTIuNSwyLjUgMCAwLDAgMTQuNSwxMi41QzE0LjUsMTIuNDMgMTQuNSwxMi4zNyAxNC41LDEyLjMxQzE0Ljg4LDEyLjU4IDE1LjM3LDEyLjc1IDE1LjksMTIuNzVDMTcuMjgsMTIuNzUgMTguNCwxMS42MyAxOC40LDEwLjI1QzE4LjQsOS4yNSAxNy44MSw4LjQgMTYuOTcsOEMxNy44MSw3LjYgMTguNCw2Ljc0IDE4LjQsNS43NUMxOC40LDQuMzcgMTcuMjgsMy4yNSAxNS45LDMuMjVDMTUuMzcsMy4yNSAxNC44OCwzLjQxIDE0LjUsMy42OUMxNC41LDMuNjMgMTQuNSwzLjU2IDE0LjUsMy41QTIuNSwyLjUgMCAwLDAgMTIsMUEyLjUsMi41IDAgMCwwIDkuNSwzLjVDOS41LDMuNTYgOS41LDMuNjMgOS41LDMuNjlDOS4xMiwzLjQxIDguNjMsMy4yNSA4LjEsMy4yNUEyLjUsMi41IDAgMCwwIDUuNiw1Ljc1QzUuNiw2Ljc0IDYuMTksNy42IDcuMDMsOEM2LjE5LDguNCA1LjYsOS4yNSA1LjYsMTAuMjVNMTIsMjJBOSw5IDAgMCwwIDIxLDEzQzE2LDEzIDEyLDE3IDEyLDIyWiI+PC9wYXRoPgogICAgICA8L2c+Cjwvc3ZnPgo=";
 
-export const plantAttributes : DropdownOption[] = [
-  { label: 'Moisture', value: 'moisture' },
-  { label: 'Conductivity', value: 'conductivity' },
-  { label: 'Temperature', value: 'temperature' },
-  { label: 'Illuminance', value: 'illuminance' },
-  { label: 'Humidity', value: 'humidity' },
-  { label: 'Daily Light Integral', value: 'dli' },
-  { label: 'DLI (24h rolling)', value: 'dli_24h' },
-  { label: 'CO2', value: 'co2' },
-  { label: 'Soil Temperature', value: 'soil_temperature' },
-  { label: 'VPD', value: 'vpd' }
+export const getPlantAttributes = (language = 'en'): DropdownOption[] => [
+  { label: getTranslation('moisture', language), value: 'moisture' },
+  { label: getTranslation('conductivity', language), value: 'conductivity' },
+  { label: getTranslation('temperature', language), value: 'temperature' },
+  { label: getTranslation('illuminance', language), value: 'illuminance' },
+  { label: getTranslation('humidity', language), value: 'humidity' },
+  { label: getTranslation('dli', language), value: 'dli' },
+  { label: getTranslation('dli_24h', language), value: 'dli_24h' },
+  { label: getTranslation('co2', language), value: 'co2' },
+  { label: getTranslation('soil_temperature', language), value: 'soil_temperature' },
+  { label: getTranslation('vpd', language), value: 'vpd' }
 ];
 
-export const careFields: DropdownOption[] = [
-  { label: 'Watering', value: 'care_watering' },
-  { label: 'Sunlight', value: 'care_sunlight' },
-  { label: 'Soil', value: 'care_soil' },
-  { label: 'Pruning', value: 'care_pruning' },
-  { label: 'Fertilization', value: 'care_fertilization' }
+export const plantAttributes: DropdownOption[] = getPlantAttributes('en');
+
+export const getCareFields = (language = 'en'): DropdownOption[] => [
+  { label: getTranslation('care_watering', language), value: 'care_watering' },
+  { label: getTranslation('care_sunlight', language), value: 'care_sunlight' },
+  { label: getTranslation('care_soil', language), value: 'care_soil' },
+  { label: getTranslation('care_pruning', language), value: 'care_pruning' },
+  { label: getTranslation('care_fertilization', language), value: 'care_fertilization' }
 ];
+
+export const careFields: DropdownOption[] = getCareFields('en');
 
 export const careIcons: Record<string, string> = {
   care_watering: 'mdi:watering-can-outline',

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -1,0 +1,113 @@
+export interface Translation {
+  [key: string]: string;
+}
+
+export interface Translations {
+  [language: string]: Translation;
+}
+
+export interface HassLanguageContext {
+  language?: string;
+  selectedLanguage?: string;
+  locale?: {
+    language?: string;
+  };
+}
+
+export const translations: Translations = {
+  en: {
+    moisture: 'Moisture',
+    conductivity: 'Conductivity',
+    temperature: 'Temperature',
+    illuminance: 'Illuminance',
+    humidity: 'Humidity',
+    dli: 'Daily Light Integral',
+    dli_24h: 'DLI (24h rolling)',
+    co2: 'CO2',
+    soil_temperature: 'Soil Temperature',
+    vpd: 'VPD',
+    care: 'Care',
+    care_watering: 'Watering',
+    care_sunlight: 'Sunlight',
+    care_soil: 'Soil',
+    care_pruning: 'Pruning',
+    care_fertilization: 'Fertilization',
+    no_care_info: 'No care information available.',
+    settings_bars: 'Bars',
+    settings_care_info: 'Care Info',
+    settings_appearance: 'Appearance',
+    settings_entity: 'Entity',
+    settings_display_name: 'Display Name',
+    settings_display_type: 'Display Type',
+    settings_battery_sensor: 'Battery Sensor',
+    settings_show_bars: 'Show Bars',
+    settings_show_care_info: 'Show Care Info',
+    settings_hide_species: 'Hide Species',
+    settings_hide_image: 'Hide Image',
+    settings_hide_units: 'Hide Units',
+    settings_full: 'Full',
+    settings_compact: 'Compact',
+  },
+  de: {
+    moisture: 'Bodenfeuchtigkeit',
+    conductivity: 'Leitfähigkeit',
+    temperature: 'Temperatur',
+    illuminance: 'Helligkeit',
+    humidity: 'Luftfeuchtigkeit',
+    dli: 'Tägliche Lichtmenge',
+    dli_24h: 'Tägliche Lichtmenge (24h rollierend)',
+    co2: 'CO2',
+    soil_temperature: 'Bodentemperatur',
+    vpd: 'VPD',
+    care: 'Pflege',
+    care_watering: 'Bewässerung',
+    care_sunlight: 'Sonnenlicht',
+    care_soil: 'Erde',
+    care_pruning: 'Rückschnitt',
+    care_fertilization: 'Düngung',
+    no_care_info: 'Keine Pflegeinformationen verfügbar.',
+    settings_bars: 'Balken',
+    settings_care_info: 'Pflegeinfo',
+    settings_appearance: 'Darstellung',
+    settings_entity: 'Entität',
+    settings_display_name: 'Anzeigename',
+    settings_display_type: 'Darstellungstyp',
+    settings_battery_sensor: 'Batteriesensor',
+    settings_show_bars: 'Balken anzeigen',
+    settings_show_care_info: 'Pflegeinfos anzeigen',
+    settings_hide_species: 'Spezies ausblenden',
+    settings_hide_image: 'Bild ausblenden',
+    settings_hide_units: 'Einheiten ausblenden',
+    settings_full: 'Voll',
+    settings_compact: 'Kompakt',
+  },
+};
+
+const germanToEnglishMapping: Translation = {
+  helligkeit: 'illuminance',
+  leitfaehigkeit: 'conductivity',
+  leitfahigkeit: 'conductivity',
+  leitfähigkeit: 'conductivity',
+  bodenfeuchtigkeit: 'moisture',
+  temperatur: 'temperature',
+  luftfeuchtigkeit: 'humidity',
+  bodentemperatur: 'soil_temperature',
+  ppfd: 'ppfd',
+  dli: 'dli',
+};
+
+export const getTranslation = (key: string, language: string = 'en'): string => {
+  const lang = language.toLowerCase().replace('_', '-').split('-')[0];
+  const normalizedKey = key.toLowerCase();
+  const englishKey = germanToEnglishMapping[normalizedKey] || key;
+
+  return translations[lang]?.[englishKey] || translations.en[englishKey] || key;
+};
+
+export const getHassLanguage = (hass: HassLanguageContext | undefined, fallback = 'en'): string => {
+  const language = typeof hass?.language === 'string' ? hass.language : undefined;
+  const selectedLanguage = typeof hass?.selectedLanguage === 'string' ? hass.selectedLanguage : undefined;
+  const localeLanguage = hass?.locale?.language;
+
+  return language || selectedLanguage || localeLanguage || fallback;
+};


### PR DESCRIPTION
### Add German localization for card UI, tooltips, care info and config editor

### Summary
This PR adds German localization support to the flower card while preserving English as the default fallback.

### What changed

- Added a centralized translation module with EN and DE dictionaries.
- Added robust key mapping for German attribute names to internal canonical keys.
- Localized attribute tooltips (for example moisture, conductivity, illuminance).
- Localized care info labels and care dialog fallback texts.
- Localized config editor labels and section titles.
- Localized config editor select options, including Full and Compact labels.
- Implemented Home Assistant language based resolution with fallback behavior.
- Kept current behavior for existing English users.

### Behavior and compatibility

- Default language remains English if no supported language is resolved.
- German translations are applied when Home Assistant language resolves to de.
- Existing configs remain compatible.
- No breaking API changes.

### - Testing

- Lint passes for modified TypeScript sources.
- Webpack build succeeds.
- Manual validation in Home Assistant:
- Attribute hover/tooltips render German labels.
- Care labels and empty-state text are translated.
- Config editor section titles, field labels, and select options are translated.

<img width="237" height="145" alt="image" src="https://github.com/user-attachments/assets/f114d640-6655-49b3-85cc-78d841f49b53" />

<img width="255" height="131" alt="image" src="https://github.com/user-attachments/assets/bb2c253d-f98a-4ee4-8021-a34c9ca5451f" />


<img width="522" height="632" alt="image" src="https://github.com/user-attachments/assets/f0adc94f-2adc-49d6-80c6-2869a257bb11" />
